### PR TITLE
Fix string substitution of list t_check

### DIFF
--- a/python/hk/scanner.py
+++ b/python/hk/scanner.py
@@ -103,7 +103,7 @@ class HKScanner:
                 info['ticks'] += len(b.t)
             if len(t_check) and abs(min(t_check) - t_this) > 60:
                 core.log_warn('data frame timestamp (%.1f) does not correspond to '
-                              'data timestamp vectors (%.1f) .' % (t_this, t_check),
+                              'data timestamp vectors (%s) .' % (t_this, t_check),
                               unit='HKScanner')
                 
         else:


### PR DESCRIPTION
This is a small bug, but if you enter the time check statement here this warning tries to sub in a list where the statement used expects a float. I've assumed we want to display the whole list, though in any example I've run the list is always a single element.

Prior to fix you'd get:
```
INFO (G3Reader): Starting file /data/15548/2019-04-09-14-59-11.g3                                                                                        
 (G3Reader.cxx:40 in void G3Reader::StartFile(std::__cxx11::string))                                                                                     
INFO (HKScanner): New HK Session id = 1, timestamp = 1554753549 (scanner.py:48 in __call__)                                                              
INFO (HKReframer): New HK Session id = 1, timestamp = 1554753549 (reframer.py:148 in __call__)                                                          
INFO (HKScanner): New HK Session id = 1, timestamp = 1554753549 (scanner.py:48 in __call__)                                                              
WARN (Unknown): Exception in module "so3g.hk.scanner.HKScanner" (G3Pipeline.cxx:121 in size_t {anonymous}::PushFrameThroughQueue(G3FramePtr, bool, bool, rusag
e&, std::vector<{anonymous}::G3Pipeline_mod_data>&, std::vector<{anonymous}::G3Pipeline_mod_data>::iterator, int&, std::deque<{anonymous}::G3Pipeline_proc_dat
a>&, G3FramePtr&))                                                                                                                                       
Traceback (most recent call last):                                                                                                                       
  File "resample.py", line 18, in <module>                                                                                                               
    p.Run()                                                                                                                                              
  File "/home/mhasse/shared/spt3g_software/build/spt3g/core/modconstruct.py", line 118, in Process                                                       
    return pycallable(fr)                                                                                                                                
  File "/home/bjk49/.local/lib/python3.7/site-packages/so3g/hk/scanner.py", line 107, in __call__                                                       
    'data timestamp vectors (%.1f) .' % (t_this, t_check),                                                                                              
TypeError: must be real number, not list
```

Afterwards the warnings look like:

```
bjk49@grumpy:~/analysis/resample$ python3 resample.py
INFO (G3Reader): Starting file /data/15548/2019-04-09-14-59-11.g3                      
 (G3Reader.cxx:40 in void G3Reader::StartFile(std::__cxx11::string))
INFO (HKScanner): New HK Session id = 1, timestamp = 1554753549 (scanner.py:48 in __call__)
INFO (HKReframer): New HK Session id = 1, timestamp = 1554753549 (reframer.py:148 in __call__)                                                                INFO (HKScanner): New HK Session id = 1, timestamp = 1554753549 (scanner.py:48 in __call__)
WARN (HKScanner): data frame timestamp (1554822031.1) does not correspond to data timestamp vectors ([1554821843.504489]) . (scanner.py:108 in __call__)
WARN (HKScanner): data frame timestamp (1554822031.1) does not correspond to data timestamp vectors ([1554821783.7016335]) . (scanner.py:108 in __call__)
WARN (HKScanner): data frame timestamp (1554822091.1) does not correspond to data timestamp vectors ([1554822030.8993309]) . (scanner.py:108 in __call__)
WARN (HKScanner): data frame timestamp (1554822091.4) does not correspond to data timestamp vectors ([1554822030.8987265]) . (scanner.py:108 in __call__)
WARN (HKScanner): data frame timestamp (1554822151.4) does not correspond to data timestamp vectors ([1554822090.8922188]) . (scanner.py:108 in __call__)
WARN (HKScanner): data frame timestamp (1554822339.0) does not correspond to data timestamp vectors ([1554822151.1164827]) . (scanner.py:108 in __call__)
```