### PR TITLE
so3g.hk: important HKReframer bug fix.

### DIFF
--- a/python/hk/reframer.py
+++ b/python/hk/reframer.py
@@ -38,7 +38,7 @@ class _HKBlockBundle:
         self.t = self.t[idx:]
         for k in self.chans.keys():
             out.data[k] = np.array(self.chans[k][:idx])
-            self.chans[k] = self.chans[k][:idx]
+            self.chans[k] = self.chans[k][idx:]
         return out
 
 

--- a/python/hk/scanner.py
+++ b/python/hk/scanner.py
@@ -101,6 +101,10 @@ class HKScanner:
                         info['span'] = min(b.t[0], t0), max(b.t[-1], t1)
                     t_check.append(b.t[0])
                 info['ticks'] += len(b.t)
+                for k,v in b.data.items():
+                    if len(v) != len(b.t):
+                        core.log_error('Field "%s" has %i samples but .t has %i samples.' %
+                                       (k, len(v), len(b.t)))
             if len(t_check) and abs(min(t_check) - t_this) > 60:
                 core.log_warn('data frame timestamp (%.1f) does not correspond to '
                               'data timestamp vectors (%.1f) .' % (t_this, t_check),


### PR DESCRIPTION
The channel data were being chopped up incorrectly.  This also adds a
check in HKScanner to catch cases where .t and .data[*] are different
sizes.