### PR TITLE
Create Dockerfile and build image with travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+dist: xenial
+
+services:
+  - docker
+
+language: python
+python:
+  - "3.6"
+
+stages:
+  - name: dockerize
+    if: |
+      branch = master AND \
+      type = push
+
+jobs:
+  include:
+    - stage: dockerize
+      install: true
+
+      before_script:
+        # Use the git tag to tag docker image
+        - export DOCKER_TAG=`git describe --tags --always`
+        # Login to docker
+        - echo "${REGISTRY_PASSWORD}" | docker login "${REGISTRY_URL}" -u "${REGISTRY_USER}" --password-stdin;
+
+      script:
+        # Build the docker image
+        - docker build -t so3g .
+        # Test import within container
+        - docker run --rm so3g /usr/bin/python3 -c 'import so3g'
+
+      after_success:
+        # Tag all images for upload to the registry
+        - "docker tag so3g:latest ${REGISTRY_URL}/so3g:latest"
+        - "docker tag so3g:latest ${REGISTRY_URL}/so3g:${DOCKER_TAG}"
+
+        # Upload to docker registry
+        - "docker push ${REGISTRY_URL}/so3g:${DOCKER_TAG}"
+        - "docker push ${REGISTRY_URL}/so3g:latest"
+        - "echo ${REGISTRY_URL}/so3g:${DOCKER_TAG} pushed"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# so3g
+# A containerized so3g installation.
+
+# Build on spt3g base image
+FROM grumpy.physics.yale.edu/spt3g:ee03194
+
+# Set the working directory
+WORKDIR /app_lib/so3g
+
+# Copy the current directory contents into the container
+ADD . /app_lib/so3g
+
+# Install any needed packages specified in requirements.txt
+RUN pip3 install -r requirements.txt
+
+# Build so3g
+RUN /bin/bash /app_lib/so3g/docker/so3g-setup.sh

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,9 @@
 so3g
 ====
 
+.. image:: https://travis-ci.com/simonsobs/so3g.svg?branch=master
+    :target: https://travis-ci.com/simonsobs/so3g
+
 Glue functions and new classes for SO work in the spt3g paradigm.
 This might turn into a permanent part of the SO software stack... but
 for now let's treat it as an experimentation and development area for

--- a/docker/so3g-setup.sh
+++ b/docker/so3g-setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+mkdir -p build
+cd build
+cmake ..
+make
+make install

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+astropy


### PR DESCRIPTION
This sets up a Travis CI pipeline for building an so3g Docker image and pushing it to the SO private registry. A new build will be triggered on any push to the master branch, tagging the image with the git tag from `git describe --tags` as well as the `latest` tag. This will facilitate providing base images for containers which need to read/write so3g files.