### PR TITLE
Downsampling while Reframing

### DIFF
--- a/python/hk/__init__.py
+++ b/python/hk/__init__.py
@@ -2,6 +2,6 @@
 Support for the SO Housekeeping format.
 """
 from .getdata import HKArchive, HKArchiveScanner
-from .reframer import HKReframer
+from .reframer import HKReframer, Downsample
 from .scanner import HKScanner
 from .session import HKSessionHelper

--- a/python/hk/reframer.py
+++ b/python/hk/reframer.py
@@ -43,7 +43,7 @@ class _HKBlockBundle:
             if downsample:
                 out.data[k] = downsample.downsample_data(self.chans[k][:idx])
             else:
-                out.data[k] = np.array(self.chans[k][:idx:downsample])
+                out.data[k] = np.array(self.chans[k][:idx])
             self.chans[k] = self.chans[k][idx:]
         return out
 


### PR DESCRIPTION
This is currently a draft, but creating a pull request now in case anyone wants to jump in early with comments.

The plan is to allow `hk.HKReframer` to optionally downsample the data. The immediate application I have in mind is for creating decimated HK archive files for live viewing, and it strikes me that it is efficient to do the downsampling at the same time that the reframing is being done.

The approach is to allow for flexibility in how the downsampling is done via the `hk.Downsample` class, an object of which can be optionally passed when an `hk.HKReframer` object is created. This base class simply implements a step size when reslicing arrays, but one can create derived classes that do more sophisticated things; my plan is to include some in so3g package (such as a downsampler that computes the median over a minimum time stride).

Perhaps also allow for a field to be multiply-downsampled, i.e., in the reframed fields, have something like `field` which is a simple mean of a field, `field_max`, `field_min` which is the maximum/minimum value in the downsampled interval, which would be handy for live display if you want to see spikes.