### PR TITLE
Full hk names

### DIFF
--- a/python/hk/getdata.py
+++ b/python/hk/getdata.py
@@ -237,8 +237,8 @@ class HKArchive:
             field readings, respectively.  In cases where two fields
             are co-sampled, the time vector will be the same object.
         """
-        if isinstance(fields, str):
-            unpack = True
+        unpack = isinstance(fields, str)
+        if unpack:
             fields = [fields]
         data, timelines = self.get_data(fields, start, end, min_stride, raw, short_match)
         output = {}


### PR DESCRIPTION
Address #20 .  This actually brings in a few useful things:

- Full feed+field names are exposed in HKArchive (so duplicated fields across providers no longer triggers buggy results).
- HKArchive.getdata() can be told to match shortened forms of field names.  So if the Archive has fields like "observatory.LS229.feeds.temps.T1", it's ok to just ask for "LS229.T1".
- New funciton HKArchive.simple() can be used to load data more effectively in interactive situations, e.g.:

```
times, temps = HKArchive.simple('LS229.T1')
plt.plot(times, temps)
```
