### PR TITLE
Clean-up tests so that they all run with unittest

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ for finding libraries.
 
 
 Local configuration through local.cmake
-=======================================
+---------------------------------------
 
 Optional, site-specific parameters may be set in the file local.cmake.
 Lines declaring set(VARIABLE, value) should have the same effect as
@@ -70,3 +70,14 @@ like this one::
 
   set(Boost_PYTHON_TYPE python-py35)
 
+Testing
+=======
+We use the built-in python unittest for testing. To run the tests install so3g
+and run::
+
+    cd test/
+    python3 -m unittest
+
+You can run specific tests by calling them directly::
+
+    python3 -m unittest test_indexed

--- a/test/test_g3ndarray.py
+++ b/test/test_g3ndarray.py
@@ -2,8 +2,16 @@ import so3g
 core = so3g.spt3g_core
 
 import numpy as np
-
 import gc
+import unittest
+
+# Don't require pixell for testing
+try:
+    from pixell import enmap
+    pixell_found = True
+except ModuleNotFoundError:
+    pixell_found = False
+
 print('Creating y')
 y = np.arange(100,200000, dtype=float)
 x = so3g.G3Ndarray(y)
@@ -29,8 +37,12 @@ print('Readback:')
 for f in core.G3File('out.g3'):
     print(f['x'])
 
-# enmap?
-from pixell import enmap
-m = enmap.zeros((100,20))
-f = core.G3Frame()
-f['test_map'] = m
+class TestG3NDArray(unittest.TestCase):
+    """TestCase for testing G3NDArrays."""
+    @unittest.skipIf(pixell_found is False, "pixell not found")
+    def test_enmap(self):
+        """Test writing enmap objects to G3Frames."""
+        # enmap?
+        m = enmap.zeros((100,20))
+        f = core.G3Frame()
+        f['test_map'] = m

--- a/test/test_hk_getdata.py
+++ b/test/test_hk_getdata.py
@@ -77,7 +77,7 @@ class TestGetData(unittest.TestCase):
 
     def tearDown(self):
         """Remove the temporary file we made."""
-        os.remove('test.g3')
+        os.remove(self._file)
 
     def test_hk_getdata_field_array_type(self):
         """Make sure we return the fields as a numpy array when we get_data."""

--- a/test/test_indexed.py
+++ b/test/test_indexed.py
@@ -1,20 +1,102 @@
-#import sys
-#sys.path.append('.')
-import so3g as ss
+import unittest
+import os
+
+import so3g
 from spt3g import core
 
-r = ss.G3IndexedReader('/home/mhasse/data/spt3g/whitenoisesample.g3')
-for i in range(10):
-    pos = r.Tell()
-    f = r.Process(None)[0]
-    print(f.type)
-    if f.type == core.G3FrameType.Wiring:
-        print('Save')
-        w_pos = pos
-        
-print ('Replay from wiring?')
-r.Seek(w_pos)
 
-for i in range(4):
-    print(r.Process(None)[0].type)
+def write_example_file(filename='hk_out.g3'):
+    """Generate an example g3 file with Wiring Frame.
 
+    This is based on other test file writing functions, but is unique in that
+    it contains a wiring frame for use in testing Seek/Tell.
+
+    Structure of frames in this file should be:
+        - Housekeeping
+        - Housekeeping
+        - Wiring
+        - Housekeeping
+        - Housekeeping
+
+    Args:
+        filename (str): filename to write data to
+
+    """
+    test_file = filename
+
+    # Write a stream of HK frames.
+    w = core.G3Writer(test_file)
+
+    # Create something to help us track the aggregator session.
+    hksess = so3g.hkagg.HKSession(session_id=1234,
+                                  description="Test HK data.")
+
+    # Register a data provider.
+    prov_id = hksess.add_provider(
+        description='Fake data for the real world.')
+
+    # Start the stream -- write the initial session and status frames.
+    f = hksess.session_frame()
+    w.Process(f)
+    f = hksess.status_frame()
+    w.Process(f)
+
+    # Write dummy wiring frame
+    f = core.G3Frame()
+    f.type = core.G3FrameType.Wiring
+    w.Process(f)
+
+    # Now make a data frame.
+    f = hksess.data_frame(prov_id=prov_id)
+
+    # Add a data block.
+    hk = so3g.IrregBlockDouble()
+    hk.prefix = 'hwp_'
+    hk.data['position'] = [1, 2, 3, 4, 5]
+    hk.data['speed'] = [1.2, 1.2, 1.2, 1.2, 1.2]
+    hk.t = [0, 1, 2, 3, 4]
+    f['blocks'].append(hk)
+
+    # Write two more housekeeping frames.
+    w.Process(f)
+    w.Process(f)
+
+    del w
+
+
+class TestG3IndexedReader(unittest.TestCase):
+    """TestCase for testing the so3g.G3IndexedReader, which has seek
+    capabilities to jump to known frames within a .g3 file.
+
+    """
+    def setUp(self):
+        self._file = 'test.g3'
+        write_example_file(self._file)
+
+    def tearDown(self):
+        """Remove the temporary data file we wrote."""
+        os.remove(self._file)
+
+    def test_seek(self):
+        """Test the Seek/Tell functionality of the G3IndexedReader. We read the
+        first four frames, recording the position of the only Wiring frame in the file
+        with Tell(). Then we Seek to that location and start reading again, expecting
+        the first frame after Seek() to be the wiring frame.
+
+        """
+        print("Testing Seek/Tell in G3IndexedReader")
+        r = so3g.G3IndexedReader(self._file)
+        # Limit the number of Process calls, if we hit the end of the file,
+        # then Seek won't work...
+        for i in range(4):
+            pos = r.Tell()
+            f = r.Process(None)[0]
+            print("  " + str(f.type))
+            if f.type == core.G3FrameType.Wiring:
+                w_pos = pos
+                print('  Saved wiring frame position: {}'.format(w_pos))
+
+        r.Seek(w_pos)
+
+        # Now that we've seeked, our next frame should be Wiring
+        assert r.Process(None)[0].type == core.G3FrameType.Wiring

--- a/test/test_pointing.py
+++ b/test/test_pointing.py
@@ -1,3 +1,6 @@
+import matplotlib
+matplotlib.use('Agg')
+
 import so3g
 import numpy as np
 import pylab as pl

--- a/test/test_pointing2.py
+++ b/test/test_pointing2.py
@@ -1,3 +1,6 @@
+import matplotlib
+matplotlib.use('Agg')
+
 import so3g
 import numpy as np
 import pylab as pl


### PR DESCRIPTION
The tests that exist are mostly individual examples. In an attempt to encourage tests be written in a more unified way we need the tests to be runnable by anyone (including eventually the Travis CI pipeline.) This PR adds instructions for how to run tests, a statement of the testing framework we're using (the out of the box `unittest` included with python), and the following modifications to existing tests:
* In `test_g3ndarray.py`, skip the part requiring pixell if it isn't installed.
* In pointing tests that produce plots, use the Agg backend to avoid plots from showing (these probably should be changed in some way to test their functionality with an assert, or moved to "examples" if their plots really need to be looked at.)
* Rework `test_indexed.py` to generate its own test file to test Seek/Tell and use the unittest framework. 

The only test that doesn't work now if you run `python3 -m unittest` within the `test/` directory is `test_pointing2.py`, since it requires pixell for setup and is quite involved. I was going to wrap the whole thing in unittest, but it seems to take command line arguments and I haven't spent the time to understand what it's doing. I'd like to maybe create an `examples/` directory, that this (and some other scripts) could live in.

While currently the Travis CI pipeline doesn't compile so3g and run the tests, recently those working on sotodlib have started working on getting this going (see https://github.com/simonsobs/sotodlib/issues/36). Once this works we should setup here to actually run the tests in Travis.