### PR TITLE
Travis test stage and spt3g version bump

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+source = python
+
+[paths]
+source =
+  /usr/lib/python3/dist-packages/so3g/
+  python/

--- a/.coveragerc
+++ b/.coveragerc
@@ -3,5 +3,5 @@ source = python
 
 [paths]
 source =
-  /usr/lib/python3/dist-packages/so3g/
   python/
+  /usr/lib/python3/dist-packages/so3g/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+build/*
+local.cmake
+.coveragerc

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+## build directory
+build/
+
+## Testing files
+.coverage
+*.g3
+
 ## Local config files.
 local.cmake
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ jobs:
       after_success:
         - pip install coveralls
         - coverage combine
+        - coverage report
+        - ls -la
         - coveralls
 
       #after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ jobs:
 
       install:
         # Build the docker images with docker-compose
+        - pip install coveralls
         - docker-compose build
     
       script: docker run -v $PWD:/coverage --rm so3g sh -c "COVERAGE_FILE=/coverage/.coverage python3 -m pytest --cov /usr/lib/python3/dist-packages/so3g/ test/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,35 +17,26 @@ stages:
 jobs:
   include:
     - stage: test
-      #before_install:
-      #  # Use the git tag to tag docker image
-      #  - export DOCKER_TAG=`git describe --tags --always`
-      #  # Login to docker
-      #  - echo "${TEST_REGISTRY_PASSWORD}" | docker login -u "${TEST_REGISTRY_USER}" --password-stdin "${TEST_REGISTRY_URL}";
-
       install:
         # Build the docker images with docker-compose
         - docker-compose build
-    
-      script: docker run -v $PWD:/coverage --rm so3g sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest --cov /usr/lib/python3/dist-packages/so3g/ test/"
+
+      script:
+        # Run tests via pytest runner with coverage in a docker container
+        - docker run -v $PWD:/coverage --rm so3g sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest --cov /usr/lib/python3/dist-packages/so3g/ test/"
 
       after_success:
+        # Install coveralls
         - pip install coveralls
+
+        # Combine results from suffixed .coverage.docker to fix paths from container testing
         - coverage combine
+
+        # Show report with updated paths
         - coverage report
-        - ls -la
+
+        # Publish results to coveralls
         - coveralls
-
-      #after_success:
-      #  # Tag all images for upload to the private test registry
-      #  - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${TEST_REGISTRY_URL}/{}:latest"
-      #  - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${TEST_REGISTRY_URL}/{}:${DOCKER_TAG}"
-
-      #  # Upload to private docker registry
-      #  - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${TEST_REGISTRY_URL}/{}:${DOCKER_TAG}"
-      #  - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${TEST_REGISTRY_URL}/{}:latest"
-      #  - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} echo ${TEST_REGISTRY_URL}/{}:${DOCKER_TAG} pushed"
-
 
     - stage: dockerize
       install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,14 @@ jobs:
 
       install:
         # Build the docker images with docker-compose
-        - pip install coveralls
         - docker-compose build
     
       script: docker run -v $PWD:/coverage --rm so3g sh -c "COVERAGE_FILE=/coverage/.coverage python3 -m pytest --cov /usr/lib/python3/dist-packages/so3g/ test/"
 
-      after_success: coveralls
+      after_success:
+        - pip install coveralls
+        - coverage combine
+        - coveralls
 
       #after_success:
       #  # Tag all images for upload to the private test registry

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
         # Build the docker images with docker-compose
         - docker-compose build
     
-      script: docker run -v $PWD:/coverage --rm so3g sh -c "COVERAGE_FILE=/coverage/.coverage python3 -m pytest --cov /usr/lib/python3/dist-packages/so3g/ test/"
+      script: docker run -v $PWD:/coverage --rm so3g sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest --cov /usr/lib/python3/dist-packages/so3g/ test/"
 
       after_success:
         - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,9 @@ jobs:
         # Build the docker images with docker-compose
         - docker-compose build
     
-      script: docker run --rm so3g sh -c "cd test/ && python3 -m unittest"
+      script: docker run -v $PWD:/coverage --rm so3g sh -c "COVERAGE_FILE=/coverage/.coverage python3 -m pytest --cov /usr/lib/python3/dist-packages/so3g/ test/"
+
+      after_success: coveralls
 
       #after_success:
       #  # Tag all images for upload to the private test registry

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - "3.6"
 
 stages:
+  - test
   - name: dockerize
     if: |
       branch = master AND \
@@ -15,6 +16,30 @@ stages:
 
 jobs:
   include:
+    - stage: test
+      #before_install:
+      #  # Use the git tag to tag docker image
+      #  - export DOCKER_TAG=`git describe --tags --always`
+      #  # Login to docker
+      #  - echo "${TEST_REGISTRY_PASSWORD}" | docker login -u "${TEST_REGISTRY_USER}" --password-stdin "${TEST_REGISTRY_URL}";
+
+      install:
+        # Build the docker images with docker-compose
+        - docker-compose build
+    
+      script: docker run --rm so3g sh -c "cd test/ && python3 -m unittest"
+
+      #after_success:
+      #  # Tag all images for upload to the private test registry
+      #  - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${TEST_REGISTRY_URL}/{}:latest"
+      #  - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${TEST_REGISTRY_URL}/{}:${DOCKER_TAG}"
+
+      #  # Upload to private docker registry
+      #  - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${TEST_REGISTRY_URL}/{}:${DOCKER_TAG}"
+      #  - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${TEST_REGISTRY_URL}/{}:latest"
+      #  - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} echo ${TEST_REGISTRY_URL}/{}:${DOCKER_TAG} pushed"
+
+
     - stage: dockerize
       install: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # A containerized so3g installation.
 
 # Build on spt3g base image
-FROM simonsobs/spt3g:reader-timeout-2f6d377
+FROM simonsobs/spt3g:7678fcc
 
 # Set the working directory
 WORKDIR /app_lib/so3g

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,9 @@ so3g
 .. image:: https://travis-ci.com/simonsobs/so3g.svg?branch=master
     :target: https://travis-ci.com/simonsobs/so3g
 
+.. image:: https://coveralls.io/repos/github/simonsobs/so3g/badge.svg?branch=master
+    :target: https://coveralls.io/github/simonsobs/so3g?branch=master
+
 .. image:: https://img.shields.io/badge/dockerhub-latest-blue
     :target: https://hub.docker.com/r/simonsobs/so3g/tags
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ ephem
 # testing
 pytest
 pytest-cov
-coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 astropy
 pytest
+pytest-cov
 matplotlib
 ephem

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 astropy
+pytest
+matplotlib
+ephem

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 astropy
-pytest
-pytest-cov
 matplotlib
 ephem
+
+# testing
+pytest
+pytest-cov
+coveralls


### PR DESCRIPTION
This PR adds a test stage to our travis pipeline. This builds the so3g docker container, then runs the tests within the container. Coverage was pretty tricky to get right, since paths are reference to the installed location within the container, but I got it working eventually (will squash these to one commit on merge.)

From here on out branches and PRs will induce a test build on travis. These should pass before merging, and should be pretty informative overall. Test coverage via coveralls provides some nice motivation for improving tests as we go too.

We also bump up the spt3g version tag to the latest commit so we can use some recently added features.