### PR TITLE
Support readthedocs, including boost-python classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ install(FILES ${MY_PYTHONS_PROJ}
         DESTINATION ${INSTALL_DEST}/proj)
 
 add_custom_target(prep-readthedocs
-  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/docs/extract_docstrings.py --prep-rtd --source-branch=docs-hacking
+  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/docs/extract_docstrings.py
+          --prep-rtd --source-branch=master
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,3 +112,8 @@ install(FILES ${MY_PYTHONS_HK}
         DESTINATION ${INSTALL_DEST}/hk)
 install(FILES ${MY_PYTHONS_PROJ}
         DESTINATION ${INSTALL_DEST}/proj)
+
+add_custom_target(prep-readthedocs
+  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/docs/extract_docstrings.py --prep-rtd --source-branch=docs-hacking
+  )
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,18 @@ from importlib import import_module
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
-sys.path.insert(0, os.path.abspath('..'))
+here = os.path.split(__file__)[0]
+repo_root = os.path.abspath(os.path.join(here, '..'))
+
+sys.path.insert(0, repo_root)
+
+if os.getenv('READTHEDOCS') == 'True':
+    os.environ['DOCS_BUILD'] = '1'
+    sys.path.insert(1, here)
+    import extract_docstrings as edocs
+    edocs.install_fake_spt3g(repo_root)
+    edocs.install_fake_so3g(repo_root)
+
 import so3g
 
 # -- Project information -----------------------------------------------------
@@ -49,6 +60,11 @@ extensions = [
     'sphinx.ext.githubpages',
     'sphinx.ext.napoleon'
 ]
+
+# Present auto-documented members in source order (rather than alphabetical).
+autodoc_default_options = {
+    'member-order': 'bysource',
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/cpp_objects.rst
+++ b/docs/cpp_objects.rst
@@ -1,0 +1,9 @@
+C++ Objects
+===========
+
+The Intervals<T> objects have the following interface:
+
+.. autoclass:: so3g.IntervalsDouble
+   :members:
+
+

--- a/docs/extract_docstrings.py
+++ b/docs/extract_docstrings.py
@@ -1,0 +1,156 @@
+import os
+import sys
+import inspect
+import re
+
+
+def install_fake_spt3g(dest_dir):
+    dest_dir = os.path.join(dest_dir, 'spt3g/core')
+    if not os.path.exists(dest_dir):
+        os.makedirs(dest_dir)
+    with open('%s/__init__.py' % dest_dir, 'w') as fout:
+        for core_class in ['G3Frame', 'quat', 'G3VectorQuat']:
+            fout.write('class %s:\n    pass\n' % core_class)
+
+
+def install_fake_so3g(dest_dir, src_dir=None):
+    if src_dir is None:
+        src_dir = '%s/python' % dest_dir
+    dest_dir = os.path.join(dest_dir, 'so3g')
+    if not os.path.exists(dest_dir):
+        os.symlink(src_dir, dest_dir)
+
+
+def create_docstring_shells(module, fout, select=None):
+    def print(text='', end='\n'):
+        fout.write(text + end)
+
+    print('# This file is generated automatically by scanning a compiled\n'
+          '# C++ boost-python module, to facilitate documentation builds.\n'
+          '# It should not be present in the master branch!\n'
+          '# Edits will be lost.\n')
+
+    for cname, cls in module.__dict__.items():
+
+        if select is not None and cname not in select:
+            continue
+
+        if cname == 'version':
+            print('def version():')
+            print('  return "%s"' % cls())
+
+        elif inspect.isclass(cls):
+            print('class %s:' % cname)
+            if hasattr(cls, '__doc__'):
+                print('  """%s"""' % cls.__doc__)
+            print('  pass')
+            for k, v in cls.__dict__.items():
+                if k[0] == '_':
+                    continue
+
+                if not inspect.isroutine(v):
+                    continue
+                # Determine staticness from the __dict__ version.
+                is_static = isinstance(v, staticmethod)
+
+                # Get the docstring from the getattr version.  (The
+                # __dict__ version doesn't work for staticmethods.)
+                docstring = getattr(cls, k).__doc__
+
+                # Attempt to extract the call signature from the first
+                # non-empty line of the docstring.
+                doclines = docstring.strip('\n').split('\n')
+                sig_line = ''
+                if len(doclines):
+                    sig_line = doclines[0]
+                m = re.fullmatch(
+                    r'(\w+)\( ' + r'(.*)' + r'\) -> (.*) :', sig_line)
+                if m is None:
+                    arglist = ['*args', '**kwargs']
+                else:
+                    _, arglist, ret_type = m.groups()
+                    arg_toks = re.findall(r'\((\w+)\)(\w+)', arglist)
+                    arglist, optional = [], False
+                    for t, n in arg_toks:
+                        if t == '':
+                            optional = True
+                        elif optional:
+                            arglist.append('%s=something' % n)
+                        else:
+                            arglist.append(n)
+
+                    # Rewrite docstring.
+                    arg_ofs = 1
+                    if is_static:
+                        arg_ofs = 0
+                    doclines[0] = ('%s(' % k
+                                   + ', '.join(arglist[arg_ofs:])
+                                   + ') -> %s' % ret_type)
+
+                if is_static:
+                    print('  @staticmethod')
+                print('  def %s():' % (k))
+                print('    """' + '\n'.join(doclines) + '"""')
+                print('    pass')
+            print()
+        else:
+            print('# No handler for "%s"\n' % cname)
+
+
+def prepare_readthedocs(src_branch='master',
+                        dest_branch='readthedocs',
+                        dest_file=None):
+    import so3g
+    if dest_file is None:
+        docs_dir = os.path.split(__file__)[0]
+        dest_file = os.path.join(
+            docs_dir, '../python/_libso3g_docstring_shells.py')
+
+    for cmd in [
+            'git checkout %s' % dest_branch,
+            'git merge --no-ff %s' % src_branch,
+            None,
+            'git add %s' % dest_file,
+            'git commit -m "Doc-ready build : %s"' % so3g.version(),
+    ]:
+        if cmd is None:
+            # Write the lib shell.
+            print('Creating docstring shells in %s...' % dest_file)
+            create_docstring_shells(so3g, open(dest_file, 'w'))
+        else:
+            print('run: %s' % cmd)
+            code = os.system(cmd)
+            if code != 0:
+                print(' FAILED with code %i' % code)
+                return 10
+    print()
+    print('Merging into the %s branch seems to have succeeded. Check that \n'
+          'everything is right and then push to github.  You are on branch:\n'
+          % dest_branch)
+    os.system('git branch --show-current')
+    print()
+    return 0
+
+
+if __name__ == '__main__':
+
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--select', action='append', default=None)
+    parser.add_argument('-o', '--output-file', default=None)
+    parser.add_argument('-p', '--prep-rtd', action='store_true')
+    parser.add_argument('--source-branch', default='master')
+    parser.add_argument('--dest-branch', default='readthedocs')
+    args = parser.parse_args()
+
+    if args.prep_rtd:
+        sys.exit(prepare_readthedocs(
+            args.source_branch, args.dest_branch, args.output_file))
+
+    else:
+        import so3g
+        if args.output_file is not None:
+            fout = open(args.output_file, 'w')
+        else:
+            fout = sys.stdout
+        create_docstring_shells(so3g, fout, select=args.select)

--- a/docs/extract_docstrings.py
+++ b/docs/extract_docstrings.py
@@ -108,10 +108,11 @@ def prepare_readthedocs(src_branch='master',
 
     for cmd in [
             'git checkout %s' % dest_branch,
+            'git pull --ff-only',
             'git merge --no-ff %s' % src_branch,
             None,
             'git add %s' % dest_file,
-            'git commit -m "Doc-ready build : %s"' % so3g.version(),
+            'git commit --allow-empty -m "Doc-ready build : %s"' % so3g.version(),
     ]:
         if cmd is None:
             # Write the lib shell.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Welcome to so3g
    intro
    hk
    proj
+   cpp_objects
 
 
 Indices and tables

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,24 +1,30 @@
-# For our compiled libraries to load, the spt3g.core library must already be loaded.
-from spt3g import core as spt3g_core
+import os
 
-# Our library is called libso3g.{suffix}, but will load into module
-# namespace so3g.
-from .load_pybindings import load_pybindings
-load_pybindings([__path__[0] + '/libso3g'], name='so3g')
+if os.getenv('DOCS_BUILD') == '1':
+    from ._libso3g_docstring_shells import *
+else:
+    # For our compiled libraries to load, the spt3g.core library must already be loaded.
+    from spt3g import core as spt3g_core
+
+    # Our library is called libso3g.{suffix}, but will load into module
+    # namespace so3g.
+    from .load_pybindings import load_pybindings
+    load_pybindings([__path__[0] + '/libso3g'], name='so3g')
 
 # Version is computed by versioneer.
 __version__ = version()
 
-# Instance configuration.
-from .config import get_config
-instance_config = get_config()
-del get_config
+if os.getenv('DOCS_BUILD') != '1':
+    # Instance configuration.
+    from .config import get_config
+    instance_config = get_config()
+    del get_config
 
-# (Possibly) monkey patch the G3Frame object with hooks for
-# so3g data types.
-from .soframe import set_frame_hooks
-set_frame_hooks(instance_config)
-del set_frame_hooks
+    # (Possibly) monkey patch the G3Frame object with hooks for
+    # so3g data types.
+    from .soframe import set_frame_hooks
+    set_frame_hooks(instance_config)
+    del set_frame_hooks
 
 # Other python modules.
 from . import hk

--- a/src/Intervals.cxx
+++ b/src/Intervals.cxx
@@ -612,59 +612,67 @@ Intervals<T> Intervals<T>::operator*(const Intervals<T> &src) const
 using namespace boost::python;
 
 #define EXPORT_INTERVALS(DOMAIN_TYPE, CLASSNAME) \
-    EXPORT_FRAMEOBJECT(CLASSNAME, init<>(), \
-   "A finite series of non-overlapping semi-open intervals on a domain " \
-   "of type: " #DOMAIN_TYPE ".") \
+    EXPORT_FRAMEOBJECT(CLASSNAME, init<>(),                             \
+        "A finite series of non-overlapping semi-open intervals on a "  \
+        "domain of type: " #DOMAIN_TYPE ".")                            \
     .def(init<const DOMAIN_TYPE&, const DOMAIN_TYPE&>("Initialize with domain.")) \
-    .def("add_interval", &CLASSNAME::add_interval, \
-         return_internal_reference<>(), \
-         "Merge an interval into the set.") \
+    .def("add_interval", &CLASSNAME::add_interval,                      \
+         return_internal_reference<>(),                                 \
+         args("self", "start", "end"),                                  \
+         "Merge an interval into the set.")                             \
     .def("append_interval_no_check", &CLASSNAME::append_interval_no_check, \
-         return_internal_reference<>(), \
+         return_internal_reference<>(),                                 \
+         args("self", "start", "end"),                                  \
          "Append an interval to the set without checking for overlap or sequence.") \
-    .def("merge", &CLASSNAME::merge, \
-         return_internal_reference<>(), \
-         "Merge an Intervals into the set.") \
-    .def("intersect", &CLASSNAME::intersect, \
-         return_internal_reference<>(), \
-         "Intersect another " #DOMAIN_TYPE "with this one.") \
-    .add_property(                                                 \
-        "domain",                                                  \
-        +[](const CLASSNAME& A) {                                  \
-             return make_tuple( A.domain.first, A.domain.second ); \
-         },                                                        \
-        +[](CLASSNAME& A, object _domain) {                        \
-             A.set_domain(extract<DOMAIN_TYPE>(_domain[0]),        \
-                          extract<DOMAIN_TYPE>(_domain[1]));       \
-         },                                                        \
-        "Interval set domain (settable, with consequences).")      \
-    .def("complement", &CLASSNAME::complement, \
-         "Return the complement (over domain).") \
-    .def("array", &CLASSNAME::array, \
-         "Return the intervals as a 2-d numpy array.") \
-    .def("from_array", &CLASSNAME::from_array,              \
-         "Return a " #DOMAIN_TYPE " based on an (n,2) ndarray.") \
-    .staticmethod("from_array")                                  \
-    .def("from_mask", &CLASSNAME::from_mask,                     \
-         "Return a list of " #CLASSNAME " extracted from an ndarray encoding a bitmask.") \
-    .staticmethod("from_mask")                                   \
+    .def("merge", &CLASSNAME::merge,                                    \
+         return_internal_reference<>(),                                 \
+         "Merge an Intervals into the set.")                            \
+    .def("intersect", &CLASSNAME::intersect,                            \
+         return_internal_reference<>(),                                 \
+         args("self", "source"),                                        \
+         "Intersect another " #DOMAIN_TYPE "with this one.")            \
+    .add_property(                                                      \
+        "domain",                                                       \
+        +[](const CLASSNAME& A) {                                       \
+             return make_tuple( A.domain.first, A.domain.second );      \
+         },                                                             \
+        +[](CLASSNAME& A, object _domain) {                             \
+             A.set_domain(extract<DOMAIN_TYPE>(_domain[0]),             \
+                          extract<DOMAIN_TYPE>(_domain[1]));            \
+         },                                                             \
+        "Interval set domain (settable, with consequences).")           \
+    .def("complement", &CLASSNAME::complement,                          \
+         "Return the complement (over domain).")                        \
+    .def("array", &CLASSNAME::array,                                    \
+         "Return the intervals as a 2-d numpy array.")                  \
+    .def("from_array", &CLASSNAME::from_array,                          \
+         args("input_array"),                                           \
+         "Return a " #CLASSNAME " based on an (n,2) ndarray.")          \
+    .staticmethod("from_array")                                         \
+    .def("from_mask", &CLASSNAME::from_mask,                            \
+         args("input_array", "n_bits"),                                 \
+         "Return a list of " #CLASSNAME ", extracted from the first \n" \
+         "n_bits bits of input_array (a 1-d array of integer type).")   \
+    .staticmethod("from_mask")                                          \
     .def("mask", &CLASSNAME::mask,                                      \
-         "Return an ndarray bitmask from a list of" #CLASSNAME ".") \
+         args("intervals_list", "n_bits"),                              \
+         "Return an ndarray bitmask from a list of " #CLASSNAME ".\n"   \
+         "The dtype will be the smallest available to hold n_bits.")    \
     .staticmethod("mask")                                               \
-    .def("copy", \
-         +[](CLASSNAME& A) { \
-              return CLASSNAME(A); \
-          }, \
-         "Get a new object with a copy of the data.") \
-    .def(-self) \
-    .def(~self) \
-    .def(self += self) \
-    .def(self -= self) \
-    .def(self + self) \
-    .def(self - self) \
-    .def(self * self); \
+    .def("copy",                                                        \
+         +[](CLASSNAME& A) {                                            \
+              return CLASSNAME(A);                                      \
+          },                                                            \
+         "Get a new object with a copy of the data.")                   \
+    .def(-self)                                                         \
+    .def(~self)                                                         \
+    .def(self += self)                                                  \
+    .def(self -= self)                                                  \
+    .def(self + self)                                                   \
+    .def(self - self)                                                   \
+    .def(self * self);                                                  \
     register_g3map<Map ## CLASSNAME>("Map" #CLASSNAME, "Mapping from "  \
-        "strings to Intervals over " #DOMAIN_TYPE ".")
+      "strings to Intervals over " #DOMAIN_TYPE ".")
 
 
 G3_SERIALIZABLE_CODE(IntervalsDouble);
@@ -679,6 +687,7 @@ G3_SERIALIZABLE_CODE(MapIntervalsTime);
 
 PYBINDINGS("so3g")
 {
+    docstring_options local_docstring_options(true, true, false);
     EXPORT_INTERVALS(double,  IntervalsDouble);
     EXPORT_INTERVALS(int64_t, IntervalsInt);
     EXPORT_INTERVALS(int32_t, IntervalsInt32);


### PR DESCRIPTION
docs/ now has code that scans a compiled version of so3g and produces
a pure-Python "shell" library with the same docstrings.  This code can
be substituted in for Sphinx to process on readthedocs.  Also some
helper functions and cmake target to cause these things to happen.
