### PR TITLE
Ranges improvements

### DIFF
--- a/docs/proj.rst
+++ b/docs/proj.rst
@@ -322,7 +322,7 @@ best way to assign pixels to threads depends on the particulars of the
 scan pattern.  So OMP should be used with care.
 
 The assignment of pixels to threads, and thus of sample-ranges to
-threads, is encoded in a ProjectionOmpData object.  To get one, try
+threads, is encoded in a RangesMatrix object.  To get one, try
 the ``Projectionist.get_prec_omp()`` method, then pass the result to
 ``to_map`` or ``from_map`` argument ``omp=``::
 
@@ -332,7 +332,7 @@ the ``Projectionist.get_prec_omp()`` method, then pass the result to
 Inspecting::
 
   >>> omp_precomp
-  <class 'so3g.proj.wcs.ProjectionOmpData'>[n_thread=4,n_det=3]
+  RangesMatrix(4,3,1)
   >>> map_pol2[:,45,106]
   array([10.        ,  4.97712898,  8.67341805])
 
@@ -340,22 +340,45 @@ Inspecting::
 Class reference
 ===============
 
-The core classes from ``so3g.proj`` are auto-documented here.
+*The core classes from* ``so3g.proj`` *are auto-documented here.  If
+you see a bunch of headings and no docstrings, then it's likely
+because the Sphinx could not import so3g properly when building the
+docs!*
 
+Assembly
+--------
 .. autoclass:: so3g.proj.Assembly
    :members:
 
+CelestialSightLine
+------------------
 .. autoclass:: so3g.proj.CelestialSightLine
    :members:
 
+EarthlySite
+-----------
 .. autoclass:: so3g.proj.EarthlySite
    :members:
 
+Projectionist
+-------------
 .. autoclass:: so3g.proj.Projectionist
    :members:
 
-.. autoclass:: so3g.proj.ProjectionOmpData
+Ranges
+------
+.. autoclass:: so3g.proj.Ranges
    :members:
 
+.. autoclass:: so3g.RangesInt32
+   :members:
+
+RangesMatrix
+------------
+.. autoclass:: so3g.proj.RangesMatrix
+   :members:
+
+Weather
+-------
 .. autoclass:: so3g.proj.Weather
    :members:

--- a/include/Ranges.h
+++ b/include/Ranges.h
@@ -25,8 +25,7 @@ public:
     Ranges(T count) : count{count}, reference(0) {}
     Ranges(T count, T reference) : count{count}, reference(reference) {}
 
-    //static Ranges<T> from_array(const bp::numpy::ndarray &src);
-    static Ranges<T> from_array(const bp::object &src);
+    static Ranges<T> from_array(const bp::object &src, int count);
 
     // Basic ops
     Ranges<T>& merge(const Ranges<T> &src);

--- a/python/proj/__init__.py
+++ b/python/proj/__init__.py
@@ -7,6 +7,7 @@ from . import util
 from .wcs import Projectionist, Ranges, RangesMatrix
 from .coords import CelestialSightLine, EarthlySite, Assembly, FocalPlane
 from .weather import Weather, weather_factory
+from .ranges import Ranges, RangesMatrix
 
 import numpy as np
 

--- a/python/proj/ranges.py
+++ b/python/proj/ranges.py
@@ -119,8 +119,7 @@ class RangesMatrix():
                     for item in items:
                         r.extend(item.ranges() + n)
                         n += item.count
-                    r = Ranges.from_array(np.array(r))
-                    r.count = n
+                    r = Ranges.from_array(np.array(r, dtype='int32'), n)
                     return r
             return RangesMatrix(ranges)
         return collect(items, axis)

--- a/python/proj/ranges.py
+++ b/python/proj/ranges.py
@@ -35,6 +35,9 @@ class RangesMatrix():
     def __len__(self):
         return self.shape[0]
 
+    def copy(self):
+        return RangesMatrix([x.copy() for x in self.ranges])
+
     @property
     def shape(self):
         if len(self.ranges) == 0:

--- a/python/proj/ranges.py
+++ b/python/proj/ranges.py
@@ -1,14 +1,11 @@
 import so3g
 import numpy as np
 
+"""Objects will self report as being of type "RangesInt32" rather than
+Ranges.  But let's try to use so3g.proj.Ranges when testing types and
+making new ones and stuff."""
 
-class Ranges(so3g.RangesInt32):
-    """This is an alias for an internal range-management type, defining
-    the general work-horse class for defining restricted sample ranges for
-    mapping operations.
-
-    """
-    pass
+Ranges = so3g.RangesInt32
 
 
 class RangesMatrix():

--- a/src/Ranges.cxx
+++ b/src/Ranges.cxx
@@ -196,7 +196,7 @@ static int format_to_dtype(const Py_buffer &view)
 
 
 template <typename T>
-Ranges<T> Ranges<T>::from_array(const bp::object &src)
+Ranges<T> Ranges<T>::from_array(const bp::object &src, int count)
 {
     Ranges<T> output;
 
@@ -221,7 +221,9 @@ Ranges<T> Ranges<T>::from_array(const bp::object &src)
         output.segments.push_back(interval_pair<T>(d, d+buf.view.strides[1]));
         d += buf.view.strides[0];
     }
+    output.count = count;
 
+    output.cleanup();
     return output;
 }
 
@@ -651,7 +653,9 @@ using namespace boost::python;
     .def("ranges", &CLASSNAME::ranges, \
          "Return the intervals as a 2-d numpy array of ranges.") \
     .def("from_array", &CLASSNAME::from_array,              \
-         "Return a " #DOMAIN_TYPE " based on an (n,2) ndarray.") \
+         "from_array(data, count) -> " #DOMAIN_TYPE "\n"         \
+         "The input data must be an (n,2) shape ndarray of int32. " \
+         "The integer count sets the domain of the object.")       \
     .staticmethod("from_array")                                  \
     .def("from_bitmask", &CLASSNAME::from_mask,                     \
          "Return a list of " #CLASSNAME " extracted from an ndarray encoding a bitmask.") \

--- a/src/Ranges.cxx
+++ b/src/Ranges.cxx
@@ -630,8 +630,12 @@ using namespace boost::python;
 
 #define EXPORT_RANGES(DOMAIN_TYPE, CLASSNAME)                           \
     EXPORT_FRAMEOBJECT(CLASSNAME, init<>(),                             \
-    "A finite series of non-overlapping semi-open intervals on a domain " \
-    "of type: " #DOMAIN_TYPE ".")                                       \
+    "A finite series of non-overlapping semi-open intervals on a domain\n" \
+    "of type: " #DOMAIN_TYPE ".\n\n"                                    \
+    "\n"                                                                \
+    "In addition to the methods explained below, note that the unary\n" \
+    "operator ~r is equivalent to r.complement() and the binary operator\n" \
+    "r1 * r2 is equivalent to (r1.copy()).intersect(r2).")              \
     .def(init<const DOMAIN_TYPE&>("Initialize with count."))            \
     .def(init<const DOMAIN_TYPE&, const DOMAIN_TYPE&>("Initialize with count and reference.")) \
     .add_property("count", &CLASSNAME::count, &CLASSNAME::safe_set_count) \

--- a/src/Ranges.cxx
+++ b/src/Ranges.cxx
@@ -632,10 +632,30 @@ using namespace boost::python;
     EXPORT_FRAMEOBJECT(CLASSNAME, init<>(),                             \
     "A finite series of non-overlapping semi-open intervals on a domain\n" \
     "of type: " #DOMAIN_TYPE ".\n\n"                                    \
+    "To create an empty object, instantiate with just a sample count:\n" \
+    "``" #CLASSNAME "(count)``.\n"                                      \
     "\n"                                                                \
-    "In addition to the methods explained below, note that the unary\n" \
-    "operator ~r is equivalent to r.complement() and the binary operator\n" \
-    "r1 * r2 is equivalent to (r1.copy()).intersect(r2).")              \
+    "Alternately, consider convenience methods such as ``from_mask``,\n" \
+    "``from_array``, and ``from_bitmask``; see below.\n"                \
+    "\n"                                                                \
+    "In addition to the methods explained below, note the that following\n" \
+    "operators have been defined and perform as follows (where ``r1`` and\n" \
+    "``r2`` are objects of this class:\n"                               \
+    "\n"                                                                \
+    "- ``~r1`` is equivalent to ``r1.complement()``\n"                  \
+    "- ``r1 *= r2`` is equivalent to ``r1.intersect(r2)``\n"            \
+    "- ``r1 += r2`` is equivalent to ``r1.merge(r2)``\n"                \
+    "- ``r1 * r2`` and ``r1 + r2`` behave as you might expect, returning a\n" \
+    "  new object and leaving ``r1`` and ``r2`` unmodified.\n"          \
+    "\n"                                                                \
+    "The object also supports slicing.  For example, if ``r1`` has\n"   \
+    "count = 100 then r1[10:-5] returns a new object (not a view)\n"    \
+    "that has count = 85.  A data member ``reference`` keeps track\n"   \
+    "of the history of shifts in the first sample; for example if\n"    \
+    "r1.reference = 0 then r1[10:-5].reference will be -10.  This\n"    \
+    "variable can be interpreted as giving the logical index, in\n"     \
+    "the new index system, of where index=0 of the original object\n"   \
+    "would be found.  This is useful for bookkeeping in some cases.\n") \
     .def(init<const DOMAIN_TYPE&>("Initialize with count."))            \
     .def(init<const DOMAIN_TYPE&, const DOMAIN_TYPE&>("Initialize with count and reference.")) \
     .add_property("count", &CLASSNAME::count, &CLASSNAME::safe_set_count) \


### PR DESCRIPTION
Fixes and improvements:
- proj.Ranges is an alias for, rather than a trivial subclass of, RangesInt32.
- docstrings in Ranges.cxx are seriously revamped, optimized for rendering in sphinx.
- .count is required in .from_array!  There's no way around this.
- .from_array calls cleanup() at the end to guard against bad user data.
- doc references to ProjectionOmpData have been removed.
- side-effect: headings for other autoclass dumps in proj.rst.
