### PR TITLE
Bump spt3g version to 0.2-11-g3444852

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # A containerized so3g installation.
 
 # Build on spt3g base image
-FROM simonsobs/spt3g:7678fcc
+FROM simonsobs/spt3g:0.2-11-g3444852
 
 # Set locale
 ENV LANG C.UTF-8


### PR DESCRIPTION
This bumps the version of the spt3g container we build the so3g container on. 0.2-11-g3444852 is the latest spt3g commit to master: https://github.com/CMB-S4/spt3g_software/commit/3444852fdd234ce5291df481e0bc421c5a43a51b