### PR TITLE
SmurfArchive system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,12 @@ docs/_build
 *.exe
 *.out
 *.app
+
+# Pycharm
+.idea
+
+#ipython
+.ipynb_checkpoints
+
+# vim
+*.swp

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Welcome to so3g
    proj
    cpp_objects
    maintenance_notes
+   smurf_archive
 
 
 Indices and tables

--- a/docs/smurf_archive.rst
+++ b/docs/smurf_archive.rst
@@ -2,7 +2,15 @@ Loading Detector Data
 ======================
 
 The SmurfArchive module contains code for indexing and quickly loading detector
-data from an archive.
+data from an archive of streamed data written by the smurf-recorder OCS agent.
+A `data archive` should contain all timestream data recorded on a given system.
+The file paths within a data archive will look like::
+
+    <archive_path>/<date-code>/<stream-id>/<filename>.g3
+
+For each stream-id, it is important that the time ranges of different files do
+not overlap or else data may not be returned in the correct order.
+
 
 Indexing Timestream Data
 --------------------------
@@ -13,7 +21,7 @@ is needed for each archive. The following snippet will write an index database
 to ``<archive_path>/frames.db`` or update an existing database with new frames
 if it already exists::
 
-    from so3g.smurf.SmurfArchive import SmurfArchive
+    from so3g.smurf import SmurfArchive
     arc = SmurfArchive('/data/timestreams')
     arc.index_archive()
 
@@ -29,14 +37,15 @@ Loading Data
 
 To load detector data that includes the range ``[start, stop]``, use::
 
-    from so3g.smurf.SmurfArchive import SmurfArchive
+    from so3g.smurf import SmurfArchive
     arc = SmurfArchive('/data/timestreams')
     times, data = arc.load_data(start, end)
 
 The following will load the a dicitonary of the ``status`` variables at a
 specified time::
 
-    from so3g.smurf.SmurfArchive import SmurfArchive
+    from so3g.smurf import SmurfArchive
+    arc = SmurfArchive('/data/timestreams')
     arc = SmurfArchive('/data/timestreams')
     status = arc.load_status(time)
 

--- a/docs/smurf_archive.rst
+++ b/docs/smurf_archive.rst
@@ -6,10 +6,14 @@ data from an archive of streamed data written by the smurf-recorder OCS agent.
 A `data archive` should contain all timestream data recorded on a given system.
 The file paths within a data archive will look like::
 
-    <archive_path>/<date-code>/<stream-id>/<filename>.g3
+    <archive-path>/<date-code>/<stream-id>/<filename>.g3
 
 For each stream-id, it is important that the time ranges of different files do
-not overlap or else data may not be returned in the correct order.
+not overlap or else data may not be returned in the correct order. This current
+version of the SmurfArchive system only works for a single stream-id, however
+future changes to the SmurfRecorder OCS agent and the SmurfArchive class will
+provide support for archives containing timestreams from multiple stream-id's.
+This change will be necessary for systems with multiple smurf cards.
 
 
 Indexing Timestream Data

--- a/docs/smurf_archive.rst
+++ b/docs/smurf_archive.rst
@@ -1,0 +1,50 @@
+Loading Detector Data
+======================
+
+The SmurfArchive module contains code for indexing and quickly loading detector
+data from an archive.
+
+Indexing Timestream Data
+--------------------------
+To index data, the SmurfArchive module will walk through an archive and record
+information about each frame to an sqlite database, including the frame time,
+frame type, the number of channels and samples, etc. Only one index database
+is needed for each archive. The following snippet will write an index database
+to ``<archive_path>/frames.db`` or update an existing database with new frames
+if it already exists::
+
+    from so3g.smurf.SmurfArchive import SmurfArchive
+    arc = SmurfArchive('/data/timestreams')
+    arc.index_archive()
+
+In this example, all detector data stored in ``/data/timestreams`` will be
+indexed and the index database will be written to
+``/data/timestreams/frames.db``.
+
+A different database path can be specified by passing the ``db_path`` argument
+to the ``SmurfArchive``.
+
+Loading Data
+-------------
+
+To load detector data that includes the range ``[start, stop]``, use::
+
+    from so3g.smurf.SmurfArchive import SmurfArchive
+    arc = SmurfArchive('/data/timestreams')
+    times, data = arc.load_data(start, end)
+
+The following will load the a dicitonary of the ``status`` variables at a
+specified time::
+
+    from so3g.smurf.SmurfArchive import SmurfArchive
+    arc = SmurfArchive('/data/timestreams')
+    status = arc.load_status(time)
+
+See the API for descriptions of possible keyword arguments
+
+API
+---
+
+.. autoclass:: so3g.smurf.SmurfArchive.SmurfArchive
+   :members: index_archive, load_data, load_status
+

--- a/python/smurf/SmurfArchive.py
+++ b/python/smurf/SmurfArchive.py
@@ -1,0 +1,252 @@
+import sqlalchemy as db
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+from spt3g import core
+import so3g
+import datetime as dt
+import os
+from tqdm import tqdm
+import numpy as np
+import yaml
+
+
+num_bias_lines = 16
+type_key = {
+    core.G3FrameType.Observation: 0,
+    core.G3FrameType.Wiring: 1,
+    core.G3FrameType.Scan: 2
+}
+
+Base = declarative_base()
+Session = sessionmaker()
+class Frame(Base):
+    """Table to store frame indexing info"""
+    __tablename__ = 'frames'
+    id = db.Column(db.Integer, primary_key=True)
+
+    # location is "<path>:<index>" and this must be unique
+    location = db.Column(db.String, nullable=False, unique=True)
+    offset = db.Column(db.Integer, nullable=False)
+    type = db.Column(db.SmallInteger, nullable=False)
+    time = db.Column(db.DateTime, nullable=False)
+
+    # Specific to data frames
+    samples = db.Column(db.Integer)
+    channels = db.Column(db.Integer)
+    start = db.Column(db.DateTime)
+    stop = db.Column(db.DateTime)
+
+    def __repr__(self):
+        return f"Frame({list(type_key.keys())[self.type]})<{self.location}>"
+
+
+class Files(Base):
+    """Table to store file indexing info"""
+    __tablename__ = 'files'
+    id = db.Column(db.Integer, primary_key=True)
+
+    path = db.Column(db.String, nullable=False)
+    start = db.Column(db.DateTime)
+    stop = db.Column(db.DateTime)
+    frames = db.Column(db.Integer)
+    channels = db.Column(db.Integer)
+
+
+
+class SmurfArchive:
+    def __init__(self, archive_path, db_path=None, echo=False):
+        """
+        Class to manage a smurf data archive.
+
+        Args
+        -----
+        archive_path (path):
+            Path to the data directory
+        db_path (path, optional):
+            Path to the sqlite file. Defaults to ``<archive_path>/frames.db``
+        echo (bool, optional):
+            If true, all sql statements will print to stdout.
+        """
+        if db_path is None:
+            db_path = os.path.join(archive_path, 'frames.db')
+        self.archive_path = archive_path
+        self.engine = db.create_engine(f"sqlite:///{db_path}", echo=echo)
+        Session.configure(bind=self.engine)
+        self.Session = sessionmaker(bind=self.engine)
+        Base.metadata.create_all(self.engine)
+
+    def add_file(self, path, session):
+        """
+        Indexes a single file and adds it to the sqlite database.
+
+        Args
+        ----
+        path (path): Path of the file to index
+        """
+        reader = so3g.G3IndexedReader(path)
+
+        total_channels = 0
+        file_start, file_stop = None, None
+        frame_idx = 0
+        while True:
+            db_frame = Frame()
+            db_frame.offset = reader.Tell()
+
+            frames = reader.Process(None)
+            if not frames:
+                break
+            frame = frames[0]
+
+            db_frame.location = f"{path}:{frame_idx:0>4}"
+            frame_idx += 1
+
+            if frame.type not in type_key.keys():
+                continue
+            db_frame.type = type_key[frame.type]
+            timestamp = frame['time'].time / core.G3Units.s
+            db_frame.time = dt.datetime.fromtimestamp(timestamp)
+
+            data = frame.get('data')
+            if data is not None:
+                db_frame.samples = data.n_samples
+                db_frame.channels = len(data)
+                db_frame.start = dt.datetime.fromtimestamp(data.start.time / core.G3Units.s)
+                db_frame.stop = dt.datetime.fromtimestamp(data.stop.time / core.G3Units.s)
+
+                if file_start is None:
+                    file_start = db_frame.start
+                file_stop = db_frame.stop
+                total_channels = max(total_channels, db_frame.channels)
+
+            session.add(db_frame)
+
+        db_file = Files(path=path, frames=frame_idx, channels=total_channels,
+                        start=file_start, stop=file_stop)
+        session.add(db_file)
+
+    def index_archive(self, verbose=False):
+        """
+        Adds all files from an archive to the sqlite database.
+        """
+        session = self.Session()
+        indexed_files = [f[0] for f in session.query(Files.path).all()]
+
+        files = []
+        for root, _, fs in os.walk(self.archive_path):
+            for f in fs:
+                path = os.path.join(root, f)
+                if path.endswith('.g3') and path not in indexed_files:
+                    files.append(path)
+
+        if verbose:
+            print(f"Indexing {len(files)} files...")
+
+        for f in tqdm(files):
+            try:
+                self.add_file(os.path.join(root, f), session)
+                session.commit()
+            except IntegrityError as e:
+                session.rollback()
+                print(e)
+            except RuntimeError as e:
+                session.rollback()
+                print(f"Failed on file {f} due to end of stream error!")
+            except Exception as e:
+                session.rollback()
+                raise e
+
+        session.close()
+
+    def load_data(self, start, end, show_pb=True, load_biases=False):
+        """
+        Loads smurf G3 data for a given time range. For the specified time range
+        this will return a chunk of data that includes that time range.
+
+        Args
+        -----
+        start (timestamp): start timestamp
+        end   (timestamp): end timestamp
+        show_pb (bool, optional): If True, will show progress bar.
+        """
+        session = self.Session()
+        frames = session.query(Frame).filter(
+            Frame.type == type_key[core.G3FrameType.Scan],
+            Frame.stop >= dt.datetime.fromtimestamp(start),
+            Frame.start < dt.datetime.fromtimestamp(end)
+        ).order_by(Frame.time)
+        session.close()
+
+        samples, channels = 0, 0
+        num_frames = 0
+        for f in frames:
+            num_frames += 1
+            samples += f.samples
+            channels = max(f.channels, channels)
+
+        timestamps = np.full((samples,), np.nan)
+        data = np.full((channels, samples), 0, dtype=np.int32)
+        if load_biases:
+            biases = np.full((num_bias_lines, samples), 0, dtype=np.int32)
+        else:
+            baises = None
+
+        cur_sample = 0
+        cur_file = None
+        for frame_info in tqdm(frames, total=num_frames, disable=(not show_pb)):
+            file = frame_info.location.split(':')[0]
+            if file != cur_file:
+                reader = so3g.G3IndexedReader(file)
+                cur_file = file
+
+            reader.Seek(frame_info.offset)
+            frame = reader.Process(None)[0]
+            nsamp = frame['data'].n_samples
+            timestamps[cur_sample:cur_sample + nsamp] = frame['data'].times()
+            key_order = [int(k[1:]) for k in frame['data'].keys()]
+            data[key_order, cur_sample:cur_sample + nsamp] = frame['data']
+            if load_biases:
+                bias_order = [int(k[-2:]) for k in frame['tes_biases'].keys()]
+                biases[bias_order, cur_sample:cur_sample + nsamp] = frame['tes_biases']
+            cur_sample += nsamp
+
+        timestamps /= core.G3Units.s
+        return timestamps, data, biases
+
+    def load_status(self, time):
+        """
+        Returns the status dict at specified unix timestamp.
+        Loads all status frames between session start frame and specified time.
+
+        Args:
+            time (timestamp): Time at which you want the rogue status
+
+        Returns:
+            status (dict): Dictionary of rogue variables at specified time.
+        """
+        session = self.Session()
+        session_start,  = session.query(Frame.time).filter(
+            Frame.type == type_key[core.G3FrameType.Observation],
+            Frame.time <= dt.datetime.fromtimestamp(time)
+        ).order_by(Frame.time.desc()).first()
+
+        status_frames = session.query(Frame).filter(
+            Frame.type == type_key[core.G3FrameType.Wiring],
+            Frame.time >= session_start,
+            Frame.time <= dt.datetime.fromtimestamp(time)
+        ).order_by(Frame.time)
+
+        status = {}
+        cur_file = None
+        for frame_info in tqdm(status_frames.all()):
+            file = frame_info.location.split(':')[0]
+            if file != cur_file:
+                reader = so3g.G3IndexedReader(file)
+                cur_file = file
+            reader.Seek(frame_info.offset)
+            frame = reader.Process(None)[0]
+            status.update(yaml.safe_load(frame['status']))
+
+        return status
+

--- a/python/smurf/SmurfArchive.py
+++ b/python/smurf/SmurfArchive.py
@@ -190,7 +190,7 @@ class SmurfArchive:
         if load_biases:
             biases = np.full((num_bias_lines, samples), 0, dtype=np.int32)
         else:
-            baises = None
+            biases = None
 
         cur_sample = 0
         cur_file = None

--- a/python/smurf/SmurfArchive.py
+++ b/python/smurf/SmurfArchive.py
@@ -201,6 +201,18 @@ class SmurfArchive:
         start (timestamp): start timestamp
         end   (timestamp): end timestamp
         show_pb (bool, optional): If True, will show progress bar.
+        load_biases (bool, optional): If True, will return biases.
+
+        Returns
+        --------
+        times (np.ndarray[samples]):
+            Array of unix timestamps for loaded data
+        data (np.ndarray[channels, samples]):
+            Array of data for each channel sending data in the specified
+            time range. The index of the array is the readout channel number.
+        biases (optional, np.ndarray[NTES, samples]):
+            An array containing the TES bias values.
+            This will only return if ``load_biases`` is set to True.
         """
         session = self.Session()
 
@@ -245,7 +257,10 @@ class SmurfArchive:
             cur_sample += nsamp
 
         timestamps /= core.G3Units.s
-        return timestamps, data, biases
+        if load_biases:
+            return timestamps, data, biases
+        else:
+            return timestamps, data
 
     def load_status(self, time, show_pb=False):
         """

--- a/python/smurf/__init__.py
+++ b/python/smurf/__init__.py
@@ -1,1 +1,3 @@
 from .reader import g3_to_array
+from .smurf_archive import SmurfArchive
+

--- a/python/smurf/smurf_archive.py
+++ b/python/smurf/smurf_archive.py
@@ -72,12 +72,12 @@ class SmurfArchive:
 
         Args
         -----
-        archive_path (path):
-            Path to the data directory
-        db_path (path, optional):
-            Path to the sqlite file. Defaults to ``<archive_path>/frames.db``
-        echo (bool, optional):
-            If true, all sql statements will print to stdout.
+            archive_path (path):
+                Path to the data directory
+            db_path (path, optional):
+                Path to the sqlite file. Defaults to ``<archive_path>/frames.db``
+            echo (bool, optional):
+                If true, all sql statements will print to stdout.
         """
         if db_path is None:
             db_path = os.path.join(archive_path, 'frames.db')
@@ -105,7 +105,7 @@ class SmurfArchive:
 
         Args
         ----
-        path (path): Path of the file to index
+            path (path): Path of the file to index
         """
 
         frame_types = {
@@ -198,21 +198,21 @@ class SmurfArchive:
 
         Args
         -----
-        start (timestamp): start timestamp
-        end   (timestamp): end timestamp
-        show_pb (bool, optional): If True, will show progress bar.
-        load_biases (bool, optional): If True, will return biases.
+            start (timestamp): start timestamp
+            end   (timestamp): end timestamp
+            show_pb (bool, optional): If True, will show progress bar.
+            load_biases (bool, optional): If True, will return biases.
 
         Returns
         --------
-        times (np.ndarray[samples]):
-            Array of unix timestamps for loaded data
-        data (np.ndarray[channels, samples]):
-            Array of data for each channel sending data in the specified
-            time range. The index of the array is the readout channel number.
-        biases (optional, np.ndarray[NTES, samples]):
-            An array containing the TES bias values.
-            This will only return if ``load_biases`` is set to True.
+            times (np.ndarray[samples]):
+                Array of unix timestamps for loaded data
+            data (np.ndarray[channels, samples]):
+                Array of data for each channel sending data in the specified
+                time range. The index of the array is the readout channel number.
+            biases (optional, np.ndarray[NTES, samples]):
+                An array containing the TES bias values.
+                This will only return if ``load_biases`` is set to True.
         """
         session = self.Session()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ matplotlib
 ephem
 pytz
 pyaml
+sqlalchemy
+pysqlite3
 
 # testing
 pytest


### PR DESCRIPTION
This PR introduces the system for indexing and efficiently loading smurf data.

The SmurfArchive system takes an archive_path and a db_path, and writes all the frame and file indexing info to an sqlite database at the specified path. The load_data function uses the index info and the G3IndexedReader to efficiently load detector and bias data between the requested start and stop times.

The `load_status` function can be used to load the current status at a specific point in time, however there is a lot more work that can be done to improve this, such as ignoring and squashing status frames where nothing has actually changed. It might be useful to index which fields in each status frame have actually changed, so people can request specific status fields without reading in every status frame. Also I think we should add a `status_timeline` function which would return a timeline for each field and the timestamps which the field changed.

This also probably needs tests, but it's been working really well for simons1 analysis so far. 

