### PR TITLE
Add an HKScanner to the HKArchiveScanner

### DIFF
--- a/python/hk/getdata.py
+++ b/python/hk/getdata.py
@@ -324,6 +324,7 @@ class HKArchiveScanner:
         self.frame_info = []
         self.counter = -1
         self.translator = so3g.hk.HKTranslator()
+        self.scanner = so3g.hk.HKScanner()
 
     def __call__(self, *args, **kw):
         return self.Process(*args, **kw)
@@ -339,6 +340,14 @@ class HKArchiveScanner:
         self.counter += 1
         if index_info is None:
             index_info = {'counter': self.counter}
+
+        # Show any errors that the scanner finds
+        core.set_log_level(core.G3LogLevel.LOG_ERROR)
+        f = self.scanner(f)
+        assert(len(f) == 1)
+        f = f[0]
+        # Reset to default log level
+        core.set_log_level(core.G3LogLevel.LOG_NOTICE)
 
         f = self.translator(f)
         assert(len(f) == 1)


### PR DESCRIPTION
Use the HKScanner to check schema validity of frames being processed by the HKArchiveScanner. This will provide more descriptive log messages when errors are encountered in HK files.

The motivation for this relates to https://github.com/simonsobs/ocs/pull/179. The OCS HK Aggregator was outputting invalid frames. Finding that was kind of a long road given the errors encountered. With this patch, when opening the files with invalid frames we get the descriptive error message:
```
ERROR (HKScanner): Frame does not have "block_names" entry, or it is not the same length as "blocks". (scanner.py:142 in __call__)
```