### PR TITLE
Make index_archive continue through file errors by default

### DIFF
--- a/python/smurf/smurf_archive.py
+++ b/python/smurf/smurf_archive.py
@@ -187,12 +187,17 @@ class SmurfArchive:
                 self.add_file(os.path.join(root, f), session)
                 session.commit()
             except IntegrityError as e:
+                # Database Integrity Errors, such as duplicate entries
                 session.rollback()
                 print(e)
             except RuntimeError as e:
+                # End of stream errors, for G3Files that were not fully flushed
                 session.rollback()
                 print(f"Failed on file {f} due to end of stream error!")
             except Exception as e:
+                # This will catch generic errors such as attempting to load
+                # out-of-date files that do not have the required frame
+                # structure specified in the TOD2MAPS docs.
                 session.rollback()
                 if stop_at_error:
                     raise e

--- a/python/smurf/smurf_archive.py
+++ b/python/smurf/smurf_archive.py
@@ -158,9 +158,16 @@ class SmurfArchive:
         db_file.frames = frame_idx
 
 
-    def index_archive(self, verbose=False):
+    def index_archive(self, verbose=False, stop_at_error=False):
         """
         Adds all files from an archive to the sqlite database.
+
+        Args
+        ----
+        verbose: bool
+            Verbose mode
+        stop_at_error: bool
+            If True, will stop if there is an error indexing a file.
         """
         session = self.Session()
         indexed_files = [f[0] for f in session.query(Files.path).all()]
@@ -187,7 +194,10 @@ class SmurfArchive:
                 print(f"Failed on file {f} due to end of stream error!")
             except Exception as e:
                 session.rollback()
-                raise e
+                if stop_at_error:
+                    raise e
+                elif verbose:
+                    print(f"Failed on file {f}:\n{e}")
 
         session.close()
 


### PR DESCRIPTION
Some old data frames taken on k2so don't have the proper format that we now require for smurf frames. This PR makes it so by default, if there is an error indexing a file, the session is rolled back but the indexing process continues. It also adds an argument `stop_at_error` which will force the `index_archive` function to stop if there is an error indexing a file.