### PR TITLE
Bump spt3g base image version to 0.3-16-g1341ea5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # A containerized so3g installation.
 
 # Build on spt3g base image
-FROM simonsobs/spt3g:0.2-11-g3444852
+FROM simonsobs/spt3g:0.3-16-g1341ea5
 
 # Set locale
 ENV LANG C.UTF-8


### PR DESCRIPTION
Motivation for this is to get Int64 support in G3VectorInt.