### PR TITLE
Add SMuRF Status wrapper

### DIFF
--- a/python/smurf/smurf_archive.py
+++ b/python/smurf/smurf_archive.py
@@ -207,7 +207,7 @@ class SmurfArchive:
 
         session.close()
 
-    def load_data(self, start, end, show_pb=True, load_biases=True):
+    def load_data(self, start, end, show_pb=True, load_biases=False):
         """
         Loads smurf G3 data for a given time range. For the specified time range
         this will return a chunk of data that includes that time range.
@@ -221,14 +221,11 @@ class SmurfArchive:
 
         Returns
         --------
-            times (np.ndarray[samples]):
-                Array of unix timestamps for loaded data
-            data (np.ndarray[channels, samples]):
-                Array of data for each channel sending data in the specified
-                time range. The index of the array is the readout channel number.
-            biases (optional, np.ndarray[NTES, samples]):
-                An array containing the TES bias values.
-                This will only return if ``load_biases`` is set to True.
+            smurf_data : namedtuple
+                Returns a tuple ``SmurfData(times, data, status, biases)``.
+                If load_biases is False, ``biases`` will be None.
+                If there are no Scan frames in the time range, ``status`` will
+                be None.
         """
         session = self.Session()
 

--- a/python/smurf/smurf_archive.py
+++ b/python/smurf/smurf_archive.py
@@ -13,11 +13,10 @@ import yaml
 import ast
 from collections import namedtuple
 
-num_bias_lines = 16
-
 
 Base = declarative_base()
 Session = sessionmaker()
+num_bias_lines = 16
 
 class Files(Base):
     """Table to store file indexing info"""


### PR DESCRIPTION
This PR adds a SmurfStatus class, which interprets the status map that is in the metadata timestream, and pulls out useful attributes to make them accessible to users. It also modifies the `load_data` function so that the status at the requested start time is always returned along with the data.

The `SmurfStatus` class also provides some utility functions `readout_to_smurf` and `smurf_to_readout` which allows users to convert between readout channel index and the `(band, channel)` pair using the channel map.