### PR TITLE
Fix bug in SmurfArchive

### DIFF
--- a/python/smurf/smurf_archive.py
+++ b/python/smurf/smurf_archive.py
@@ -436,9 +436,13 @@ class SmurfStatus:
         # Calculates flux ramp reset rate (Pulled from psmurf's code)
         rtm_root = 'AMCc.FpgaTopLevel.AppTop.AppCore.RtmCryoDet'
         ramp_max_cnt = self.status.get(f'{rtm_root}.RampMaxCnt')
-        digitizer_freq_mhz = float(self.status.get(f'{band_roots[0]}.digitizerFrequencyMHz', 614.4))
-        ramp_max_cnt_rate_hz = 1.e6*digitizer_freq_mhz / 2.
-        self.flux_ramp_rate_hz = ramp_max_cnt_rate_hz / (ramp_max_cnt + 1)
+        if ramp_max_cnt is None:
+            self.flux_ramp_rate_hz = 4000
+        else:
+            digitizer_freq_mhz = float(self.status.get(
+                f'{band_roots[0]}.digitizerFrequencyMHz', 614.4))
+            ramp_max_cnt_rate_hz = 1.e6*digitizer_freq_mhz / 2.
+            self.flux_ramp_rate_hz = ramp_max_cnt_rate_hz / (ramp_max_cnt + 1)
 
     def readout_to_smurf(self, rchan):
         """

--- a/python/smurf/smurf_archive.py
+++ b/python/smurf/smurf_archive.py
@@ -437,7 +437,7 @@ class SmurfStatus:
         rtm_root = 'AMCc.FpgaTopLevel.AppTop.AppCore.RtmCryoDet'
         ramp_max_cnt = self.status.get(f'{rtm_root}.RampMaxCnt')
         if ramp_max_cnt is None:
-            self.flux_ramp_rate_hz = 4000
+            self.flux_ramp_rate_hz = None
         else:
             digitizer_freq_mhz = float(self.status.get(
                 f'{band_roots[0]}.digitizerFrequencyMHz', 614.4))


### PR DESCRIPTION
This fixes a bug in the new Smurf status class which would cause data loading to crash when the `RampMaxCnt` was not found in the metadata stream.