### PR TITLE
Changed load_data to return squid phase instead of ADC counts

### DIFF
--- a/docs/smurf_archive.rst
+++ b/docs/smurf_archive.rst
@@ -43,17 +43,12 @@ To load detector data that includes the range ``[start, stop]``, use::
 
     from so3g.smurf import SmurfArchive
     arc = SmurfArchive('/data/timestreams')
-    times, data = arc.load_data(start, end)
+    d = arc.load_data(start, end)
 
-The following will load the a dicitonary of the ``status`` variables at a
-specified time::
-
-    from so3g.smurf import SmurfArchive
-    arc = SmurfArchive('/data/timestreams')
-    arc = SmurfArchive('/data/timestreams')
-    status = arc.load_status(time)
-
-See the API for descriptions of possible keyword arguments
+The data will be loaded into a named_tuple which contains the detector data,
+primary data, and TES bias values, and metadata status. See the `load_data` Api
+for a more detailed description of allowed keyword arguments and the return
+value.
 
 API
 ---

--- a/python/smurf/smurf_archive.py
+++ b/python/smurf/smurf_archive.py
@@ -275,9 +275,9 @@ class SmurfArchive:
                 times (np.ndarray[samples]):
                     Array of unix timestamps for loaded data
                 data (np.ndarray[channels, samples]):
-                    Array of data for each channel sending data in the
-                    specified time range. The index of the array is the readout
-                    channel number.
+                    Array of the squid phase in units of radiansa for each
+                    channel with data in the specified time range. The index of
+                    the array is the readout channel number.
                 primary (Dict[np.ndarray]):
                     Dict of numpy arrays holding the "primary" data included in
                     the packet headers, including 'AveragingResetBits',
@@ -356,6 +356,10 @@ class SmurfArchive:
             timestamps[cur_sample:cur_sample + nsamp] = ts
 
             cur_sample += nsamp
+
+        # Conversion from DAC counts to squid phase
+        rad_per_count = np.pi / 2**15
+        data = data * rad_per_count
 
         if len(timestamps) > 0:
             status = self.load_status(timestamps[0])

--- a/python/smurf/smurf_archive.py
+++ b/python/smurf/smurf_archive.py
@@ -275,7 +275,7 @@ class SmurfArchive:
                 times (np.ndarray[samples]):
                     Array of unix timestamps for loaded data
                 data (np.ndarray[channels, samples]):
-                    Array of the squid phase in units of radiansa for each
+                    Array of the squid phase in units of radians for each
                     channel with data in the specified time range. The index of
                     the array is the readout channel number.
                 primary (Dict[np.ndarray]):


### PR DESCRIPTION
This PR changes the `load_data` function so that it returns data in units of squid phase instead of ADC counts. This may break the few analysis scripts written so far that use the function, but I think it's important to change this now rather than later. I can send a slack message to notify people who are using this function, which I think is mostly @kmharrington, @jeffiuliano, myself and a few people at UCSD.

I've also updated the `load_data` docs to be consistent with the last couple of pull requests. 

This PR will resolve https://github.com/simonsobs/smurf-issues/issues/18.