### PR TITLE
Update coveralls command for v3.0.0

### DIFF
--- a/.github/workflows/official-docker-images.yml
+++ b/.github/workflows/official-docker-images.yml
@@ -36,7 +36,7 @@ jobs:
         pip install coveralls
         coverage combine
         coverage report
-        coveralls
+        coveralls --service=github
 
     # Dockerize
     - name: Build and push official docker image

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,4 +31,4 @@ jobs:
         pip install coveralls
         coverage combine
         coverage report
-        coveralls
+        coveralls --service=github

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,9 @@
 so3g
 ====
 
-.. image:: https://travis-ci.com/simonsobs/so3g.svg?branch=master
-    :target: https://travis-ci.com/simonsobs/so3g
+.. image:: https://img.shields.io/github/workflow/status/simonsobs/so3g/Build%20Official%20Docker%20Images/master
+    :target: https://github.com/simonsobs/so3g/actions?query=workflow%3A%22Build+Official+Docker+Images%22
+    :alt: GitHub Workflow Status (branch)
 
 .. image:: https://readthedocs.org/projects/so3g/badge/?version=latest
     :target: https://so3g.readthedocs.io/en/latest/?badge=latest


### PR DESCRIPTION
v3.0.0 of coveralls-python now requires `--service` be specified for things to
work with Github Actions. See [1].

[1] - TheKevJames/coveralls-python#251