### PR TITLE
Update to Ubuntu 20.04 based spt3g image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,17 @@
 # A containerized so3g installation.
 
 # Build on spt3g base image
-FROM simonsobs/spt3g:0.3-16-g1341ea5
+FROM simonsobs/spt3g:0.3-23-gd903080
 
 # Set locale
 ENV LANG C.UTF-8
 
 # Build tools needed for pixell; blas needed for so3g.
-RUN apt install -y build-essential automake gfortran libopenblas-dev
+RUN apt install -y build-essential \
+    automake \
+    gfortran \
+    libopenblas-dev \
+    python-is-python3
 
 # Set the working directory
 WORKDIR /app_lib/so3g


### PR DESCRIPTION
Also add python to python3 symlink package. In Ubuntu 20.04 systems python is always explicitly python2 or python3 in packages, so they drop `python` all together. Somewhere in so3g it uses `python` and would fail if the symlink didn't exist. I'm fine with this solution, but if someone who knows more about the build system wanted to explicitly state python3, that'd be great too.