### PR TITLE
G3SuperTimestream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(so3g SHARED
   src/Ranges.cxx
   src/Rebundler.cxx
   src/Projection.cxx
+  src/G3SuperTimestream.cxx
   src/so_linterp.cxx
   src/exceptions.cxx
   src/array_ops.cxx

--- a/docs/cpp_objects.rst
+++ b/docs/cpp_objects.rst
@@ -1,11 +1,118 @@
 C++ Objects
 ===========
 
+Intervals
+---------
+
 The Intervals<T> objects have the following interface:
 
 .. autoclass:: so3g.IntervalsDouble
    :members:
 
+G3SuperTimestream
+-----------------
+
+G3SuperTimestream is for storing 2d arrays of data where the first
+axis corresponds to named channels and the second axis indexes time.
+The data arrays can have int32, int64, float32, or float64 data types.
+It has configurable compression options in order to accomodate different
+kinds of data.
+
+For arrays of integers, lossless compression is enabled by default.
+For arrays of floats, compression can be enabled that will be lossless
+over a reduced dynamic and precision range.
+
+Creating a G3SuperTimestream
+````````````````````````````
+
+When building a G3SuperTimestream, you must first populate the axis
+information, then load in the data.  Here is an example::
+
+  # imports
+  from spt3g import core
+  import so3g
+  import numpy as np
+
+  # The data we want to capture
+  times = 1680000000 + 0.2 * np.arange(10000)
+  names = ['a', 'b', 'c', 'd', 'e']
+  data = (np.random.normal(size=(len(names), len(times))) * 256).astype('int32')
+
+  # Creation of a G3SuperTimestream
+  ts = so3g.G3SuperTimestream()
+  ts.names = names
+  ts.times = core.G3VectorTime(times * core.G3Units.s)
+  ts.data = data
+
+
+The object is now complete, and can be serialized.  In the default
+configuration, arrays with int32 or int64 data types will be
+compressed losslessly using a combination of FLAC and bzip.
+
+Controlling Compression
+```````````````````````
+
+You can trigger compression of the data by calling ``.encode()``.  The
+reference in ``.data`` is released, and a binary blob with compressed
+data is saved internally.  If you try to access ``.data`` after
+calling ``.encode()``, a new array will be created (by decompressing
+the blob) and returned.
+
+Compression will be triggered automatically on frame serialization
+(i.e. when the frame is written to a file or network stream).  Because
+serialization is a const operation, the binary blob of compressed data
+is not stored in this case, and the reference to ``.data`` is not
+released.  So there may be performance advantages to calling
+``.encode()`` "manually" before passing your object through to
+consumers that might want to use it in serialized form.
+
+It is possible to tweak the compression algorithm, but this should be
+done with care.  By calling ``.options(data_algo=ALGO)`` you can set
+the internal algorithm to one of the following:
+
+- ALGO = 0: No compression, just store unmodified binary data.
+- ALGO = 1: Use FLAC only.  This limits the dynamic range of the data
+  to 24 bits and thus is not lossless if your input data exceeds this
+  range.
+- ALGO = 2: Use bzip only.  This is lossless but will not be efficient
+  for "noisy" data.  There might be a use case here for arrays
+  carrying slowly-changing bit-fields.
+- ALGO = 3: Use FLAC+bzip (the default).  This is lossless and should
+  perform well on noisy data.
+
+On serialization, the ``.times`` vector is also compressed, using
+bzip.  This can be disabled by passing ``.options(times_algo=0)``.
+
+
+How to work with float arrays
+`````````````````````````````
+
+This object is not suitable for lossless compression of float32 and
+float64 arrays.  Instead, the user must specify a precision
+(e.g. 0.001), and then the compression works like this:
+
+- The array of floats *x* is converted to integers, *y = round(x /
+  precision)*.  If *x* is float32, then *y* will be packed into
+  int32.  If *x* is float64, then *y* will be int64.
+- The integer array *y* is compressed according to the lossless scheme
+  used for integer data.
+
+The precision of a particular non-zero float32 is approximately
+:math:`2^{-23} = 1.2e-7` times its magnitude.  If we fix the precision
+at 0.001, then the set of numbers that can be safely encoded by our
+float32 scheme is all multiples of 0.001 between -8388.6 and +8388.6.
+
+Equivalently for float64 the precision is :math:`2^{-52} = 2.2e-16`
+times magnitude, so with a precision of 0.001 we have dynamic range of
+about -4.5e12 to +4.5e12.
+
+When a G3SuperTimestream is carrying float-type arrays, the user must
+specify the precision with a call to ``.options(precision=...)``
+before calling ``.encode()`` or triggering serialization.
+
+
+Interface autodoc
+`````````````````
 
 .. autoclass:: so3g.G3SuperTimestream
    :members:

--- a/docs/cpp_objects.rst
+++ b/docs/cpp_objects.rst
@@ -7,3 +7,5 @@ The Intervals<T> objects have the following interface:
    :members:
 
 
+.. autoclass:: so3g.G3SuperTimestream
+   :members:

--- a/include/G3SuperTimestream.h
+++ b/include/G3SuperTimestream.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "so3g_numpy.h"
+#include <G3Frame.h>
+#include <G3Map.h>
+
+#include <exception>
+#include <stdint.h>
+
+using namespace std;
+
+class G3SuperTimestream : public G3FrameObject {
+	// Storage for a set of co-sampled data vectors, the single
+	// vector of associated timestamps, and the vector of channel
+	// names.
+public:
+	G3VectorTime times;
+	G3VectorString names;
+
+	string Description() const;
+	string Summary() const;
+
+	bool Encode(int codec);
+	bool Decode();
+
+	template <class A> void load(A &ar, unsigned v);
+	template <class A> void save(A &ar, unsigned v) const;
+
+	struct array_desc {
+		npy_intp type_num;
+		npy_intp ndim;
+		npy_intp shape[32];
+		npy_intp item_size;
+		npy_intp nbytes;
+	};
+	struct flac_block {
+		int size;
+		char *buf;
+		int count;
+		vector<int> offsets;
+	};
+
+	PyArrayObject *array;
+	struct array_desc desc;
+	struct flac_block *flac;
+};
+
+// This specialization tells cereal to use G3SuperTimestream::serialize
+// and not the base class' load/save.
+namespace cereal {
+	template <class A> struct specialize<
+		A, G3SuperTimestream, cereal::specialization::member_load_save> {};
+}
+
+G3_POINTERS(G3SuperTimestream);
+G3_SERIALIZABLE(G3SuperTimestream, 0);
+
+class g3supertimestream_exception : std::exception
+{
+	// Exception raised when internal validity checks fail.  This will
+	// also be mapped to some particular Python exception type.
+public:
+	std::string text;
+g3supertimestream_exception(std::string text) :
+        text{text} {}
+
+	std::string msg_for_python() const throw() {
+		return text;
+	}
+};

--- a/include/G3SuperTimestream.h
+++ b/include/G3SuperTimestream.h
@@ -22,7 +22,7 @@ public:
 	string Description() const;
 	string Summary() const;
 
-	bool Encode(int codec);
+	bool Encode(float precision);
 	bool Decode();
 
 	template <class A> void load(A &ar, unsigned v);

--- a/include/G3SuperTimestream.h
+++ b/include/G3SuperTimestream.h
@@ -36,10 +36,13 @@ public:
 		npy_intp nbytes;
 	};
 	struct flac_block {
+		float precision;
 		int size;
 		char *buf;
 		int count;
 		vector<int> offsets;
+		vector<int32_t> pivots;
+		vector<int> warnings;
 	};
 
 	PyArrayObject *array;

--- a/include/G3SuperTimestream.h
+++ b/include/G3SuperTimestream.h
@@ -14,6 +14,8 @@ class G3SuperTimestream : public G3FrameObject {
 	// vector of associated timestamps, and the vector of channel
 	// names.
 public:
+	~G3SuperTimestream();
+
 	G3VectorTime times;
 	G3VectorString names;
 

--- a/src/G3SuperTimestream.cxx
+++ b/src/G3SuperTimestream.cxx
@@ -12,7 +12,72 @@
 #include <cereal/types/utility.hpp>
 
 #include <FLAC/stream_encoder.h>
+#include <bzlib.h>
 
+// Debugging variables for compressors.
+// Must range from 0 (silent) to 4.
+#define SO3G_BZ2_VERBOSITY 0
+
+static
+std::string get_bz2_error_string(int err) {
+	std::ostringstream s;
+	switch(err) {
+	case BZ_CONFIG_ERROR:
+		s << "BZ_CONFIG_ERROR (library compilation issue)";
+		break;
+	case BZ_PARAM_ERROR:
+		s <<  "BZ_PARAM_ERROR (bad blocksize, verbosity, etc)";
+		break;
+	case BZ_MEM_ERROR:
+		s << "BZ_MEM_ERROR (not enough memory is available)";
+		break;
+	case BZ_OK:
+		s << "BZ_OK (no problem)";
+	default:
+		s << "Unknown error code " << err;
+	}
+	return s.str();
+}
+
+static
+std::string get_algo_error_string(std::string var_name, int algo_code)
+{
+	std::ostringstream s;
+	s << "No support for compression algorithm " << var_name << "=" << algo_code;
+	return s.str();
+}
+
+// Split each datum in x into:
+//
+//    x[i] = r[i] + y[i]
+//
+// where r is a multiple of snap_to, -step_at <= y[i] < step_at.  The
+// algorithm tries to have r[i] change slowly, meaning that r[i+1]
+// will not differ from r[i] unless necessary to satisfy the
+// range restriction on y[i].
+//
+// This is only implemented for snap_to and step_at both powers of 2!
+//
+// Let's allow r and x to point to same memory.
+template <typename T>
+static
+int rebranch(int32_t *y, T *r, T *x, int n_samps, T snap_to, T step_at)
+{
+	T branch = 0;
+	int fails = 0;
+	for (int i=0; i < n_samps; i++) {
+		T new_branch = (x[i] + snap_to / 2) & ~(snap_to - 1);
+		if (new_branch - branch >= step_at ||
+		    new_branch - branch <  -step_at)
+			branch = new_branch;
+		y[i] = x[i] - branch;
+		// Don't update r until you use x -- they are allowed to overlap.
+		r[i] = branch;
+		if (y[i] < -step_at || y[i] >= step_at)
+			fails++;
+	}
+	return fails;
+}
 
 FLAC__StreamEncoderWriteStatus flac_encoder_write_cb(
 	const FLAC__StreamEncoder *encoder,
@@ -29,9 +94,9 @@ FLAC__StreamEncoderWriteStatus flac_encoder_write_cb(
 	return FLAC__STREAM_ENCODER_WRITE_STATUS_OK;
 }
 
-
 static
-struct G3SuperTimestream::flac_block encode_flac(PyArrayObject *array, float precision)
+struct G3SuperTimestream::flac_block encode_flac_bz2(
+	int8_t data_algo, PyArrayObject *array, float precision)
 {
 	struct G3SuperTimestream::flac_block fb;
 	int n = PyArray_NBYTES(array);
@@ -46,50 +111,71 @@ struct G3SuperTimestream::flac_block encode_flac(PyArrayObject *array, float pre
 	int32_t d[n_samps];
 	const int32_t *chan_ptrs[1] = {d};
 
+	char r[n_samps * sizeof(int64_t)];
+	auto r32 = (int32_t*)r;
+	auto r64 = (int64_t*)r;
+
 	npy_intp type_num = PyArray_TYPE(array);
 	char *src = (char*)(PyArray_DATA(array));
-	FLAC__StreamEncoder *encoder = FLAC__stream_encoder_new();
+	FLAC__StreamEncoder *encoder = nullptr;
+	if (data_algo & G3SuperTimestream::ALGO_DO_FLAC)
+		encoder = FLAC__stream_encoder_new();
 
 	int32_t M = (1 << 24);
 	for (int i=0; i< PyArray_DIMS(array)[0]; i++, src+=PyArray_STRIDES(array)[0]) {
-		int32_t pivot = 0;
-		int warnings = 0;
-		if (type_num == NPY_INT32) {
-			pivot = round(double(((int32_t*)src)[0]) / M) * M;
-			for (int i=0; i < n_samps; i++) {
-				d[i] = ((int32_t*)src)[i] + pivot;
-				if (d[i] >= M/2 || d[i] < -M/2)
-					warnings++;
-			}
-		} else if (type_num == NPY_INT64) {
-			pivot = round(double(((int64_t*)src)[0]) / M) * M;
-			for (int i=0; i < n_samps; i++) {
-				d[i] = ((int64_t*)src)[i] + pivot;
-				if (d[i] >= M/2 || d[i] < -M/2)
-					warnings++;
-			}
-		} else if (type_num == NPY_FLOAT32) {
-			for (int i=0; i < n_samps; i++)
-				d[i] = (int32_t)(round(((float*)src)[i] / precision));
-		} else if (type_num == NPY_FLOAT64) {
-			for (int i=0; i < n_samps; i++)
-				d[i] = (int32_t)(round(((double*)src)[i] / precision));
-		} else
-			throw g3supertimestream_exception("Invalid array type encountered.");
+		if (encoder != nullptr) {
+			int fails = 0;
+			if (type_num == NPY_INT32) {
+				fails = rebranch<int32_t>(d, r32, (int32_t*)src, n_samps, M, M/2);
+			} else if (type_num == NPY_INT64) {
+				fails = rebranch<int64_t>(d, r64, (int64_t*)src, n_samps, M, M/2);
+			} else if (type_num == NPY_FLOAT32) {
+				for (int j=0; j < n_samps; j++)
+					r32[j] = roundf(((float*)src)[j] / precision);
+				fails = rebranch<int32_t>(d, r32, r32, n_samps, M, M/2);
+			} else if (type_num == NPY_FLOAT64) {
+				for (int j=0; j < n_samps; j++)
+					r64[j] = round(((double*)src)[j] / precision);
+				fails = rebranch<int64_t>(d, r64, r64, n_samps, M, M/2);
+			} else
+				throw g3supertimestream_exception("Invalid array type encountered.");
+			if (fails > 0)
+				throw g3supertimestream_exception("Data fail.");
 
-		FLAC__stream_encoder_set_channels(encoder, 1);
-		FLAC__stream_encoder_set_bits_per_sample(encoder, 24);
-		FLAC__stream_encoder_set_compression_level(encoder, 1);
-		FLAC__stream_encoder_init_stream(
-			encoder, flac_encoder_write_cb, NULL, NULL, NULL, (void*)(&fb));
-		FLAC__stream_encoder_process(encoder, chan_ptrs, n_samps);
-		FLAC__stream_encoder_finish(encoder);
-
+			FLAC__stream_encoder_set_channels(encoder, 1);
+			FLAC__stream_encoder_set_bits_per_sample(encoder, 24);
+			FLAC__stream_encoder_set_compression_level(encoder, 1);
+			FLAC__stream_encoder_init_stream(
+				encoder, flac_encoder_write_cb, NULL, NULL, NULL, (void*)(&fb));
+			FLAC__stream_encoder_process(encoder, chan_ptrs, n_samps);
+			FLAC__stream_encoder_finish(encoder);
+		} else {
+			memcpy(r, src, n_samps * PyArray_ITEMSIZE(array));
+			if (type_num == NPY_FLOAT32) {
+				for (int j=0; j<n_samps; j++)
+					((int32_t*)r)[j] = roundf(((float*)r)[j] / precision);
+			} else if (type_num == NPY_FLOAT64) {
+				for (int j=0; j<n_samps; j++)
+					((int64_t*)r)[j] = round(((double*)r)[j] / precision);
+			}
+		}
 		fb.offsets.push_back(fb.count);
-		fb.pivots.push_back(pivot);
-		fb.warnings.push_back(warnings);
+
+		// And the bz2
+		if (data_algo & G3SuperTimestream::ALGO_DO_BZ) {
+			assert(fb.size > fb.count);
+			unsigned int n_write = fb.size - fb.count;
+			int err = BZ2_bzBuffToBuffCompress(
+				fb.buf + fb.count, &n_write, r, n_samps * PyArray_ITEMSIZE(array),
+				5, SO3G_BZ2_VERBOSITY, 1);
+			if (err != BZ_OK)
+				throw g3supertimestream_exception(get_bz2_error_string(err));
+			fb.count += n_write;
+		}
+		fb.offsets.push_back(fb.count);
 	}
-	FLAC__stream_encoder_delete(encoder);
+	if (encoder != nullptr)
+		FLAC__stream_encoder_delete(encoder);
 
 	return fb;
 }
@@ -114,67 +200,140 @@ template <class A> void G3SuperTimestream::load(A &ar, unsigned v)
 {
 	using namespace cereal;
 	ar & make_nvp("parent", base_class<G3FrameObject>(this));
-	ar & make_nvp("times", times);
+
+	ar & make_nvp("times_algo", options.times_algo);
+
+	if (options.times_algo == ALGO_NONE) {
+		ar & make_nvp("times", times);
+	} else if (options.times_algo == ALGO_DO_BZ) {
+		int n_samps;
+		ar & make_nvp("n_samps", n_samps);
+		times.resize(n_samps);
+
+		int max_bytes = 0;
+		ar & make_nvp("comp_bytes", max_bytes);
+
+		char *buf = (char*)malloc(max_bytes);
+		ar & make_nvp("times_data", binary_data(buf, max_bytes));
+		unsigned int n_decomp = n_samps * sizeof(times[0]);
+		int err = BZ2_bzBuffToBuffDecompress(
+			     (char*)&times[0], &n_decomp, buf, max_bytes,
+			     1, SO3G_BZ2_VERBOSITY);
+		if (err != BZ_OK)
+			throw g3supertimestream_exception(get_bz2_error_string(err));
+		free(buf);
+	} else
+		throw g3supertimestream_exception(
+			get_algo_error_string("times_algo", options.times_algo));
+
 	ar & make_nvp("names", names);
 
 	// Read the desc.
         ar & make_nvp("type_num", desc.type_num);
         ar & make_nvp("ndim", desc.ndim);
 	ar & make_nvp("shape", desc.shape);
-        ar & make_nvp("item_size", desc.item_size);
         ar & make_nvp("nbytes", desc.nbytes);
 
-	// Read the flacblock
-	flac = new struct flac_block;
-	ar & make_nvp("precision", flac->precision);
-	ar & make_nvp("payload_bytes", flac->count);
-	ar & make_nvp("offsets", flac->offsets);
-	ar & make_nvp("pivots", flac->pivots);
-	flac->buf = new char[flac->count];
-	ar & make_nvp("payload", binary_data(flac->buf, flac->count));
+	ar & make_nvp("data_algo", options.data_algo);
+	if (options.data_algo == ALGO_NONE) {
+		assert(PyArray_EquivByteorders(NPY_NATIVE, NPY_LITTLE)); // Check it's not 1997
+		array = (PyArrayObject*)
+			PyArray_SimpleNew(desc.ndim, desc.shape, desc.type_num);
+		ar & make_nvp("data_raw", binary_data((char*)PyArray_DATA(array),
+						      PyArray_NBYTES(array)));
+	} else {
+		// Read the flacblock
+		flac = new struct flac_block;
+		ar & make_nvp("precision", flac->precision);
+		ar & make_nvp("offsets", flac->offsets);
+		ar & make_nvp("payload_bytes", flac->count);
+		flac->buf = new char[flac->count];
+		ar & make_nvp("payload", binary_data(flac->buf, flac->count));
+	}
 }
 
 template <class A> void G3SuperTimestream::save(A &ar, unsigned v) const
 {
 	using namespace cereal;
 	ar & make_nvp("parent", base_class<G3FrameObject>(this));
-	ar & make_nvp("times", times);
-	ar & make_nvp("names", names);
 
-	struct flac_block *_flac = flac;
-	if (_flac == nullptr) {
-		// Encode to a copy.
-		_flac = new struct flac_block;
-		*_flac = encode_flac(array, 1.);
-        }
+	ar & make_nvp("times_algo", options.times_algo);
+
+	if (options.times_algo == ALGO_NONE) {
+		// No compression.
+		ar & make_nvp("times", times);
+	} else if (options.times_algo == ALGO_DO_BZ) {
+		int n_samps = times.size();
+		ar & make_nvp("n_samps", n_samps);
+
+		unsigned int max_bytes = n_samps * sizeof(times[0]);
+		char *buf = (char*)malloc(max_bytes);
+		int err = BZ2_bzBuffToBuffCompress(
+			buf, &max_bytes, (char*)&times[0], max_bytes,
+			     5, SO3G_BZ2_VERBOSITY, 1);
+		if (err != BZ_OK)
+			throw g3supertimestream_exception(get_bz2_error_string(err));
+		ar & make_nvp("comp_bytes", max_bytes);
+		ar & make_nvp("times_data", binary_data(buf, max_bytes));
+		free(buf);
+	} else
+		throw g3supertimestream_exception(
+			get_algo_error_string("times_algo", options.times_algo));
+
+	ar & make_nvp("names", names);
 
 	// Write the desc.
         ar & make_nvp("type_num", desc.type_num);
         ar & make_nvp("ndim", desc.ndim);
 	ar & make_nvp("shape", desc.shape);
-        ar & make_nvp("item_size", desc.item_size);
         ar & make_nvp("nbytes", desc.nbytes);
 
-	// Write the flacblock
-	//ar & make_nvp("codec", 1);
-	ar & make_nvp("precision", _flac->precision);
-	ar & make_nvp("payload_bytes", _flac->count);
-	ar & make_nvp("offsets", _flac->offsets);
-	ar & make_nvp("pivots", _flac->pivots);
-	ar & make_nvp("payload", binary_data(_flac->buf, _flac->count));
+	ar & make_nvp("data_algo", options.data_algo);
+	if (options.data_algo == ALGO_NONE) {
+		assert(array != nullptr);
+		// Check the endianness
+		auto this_descr = PyArray_DESCR(array);
+		assert(PyArray_EquivByteorders(this_descr.byte_order, NPY_LITTLE));
+
+		// Might as well use numpy to repack it properly...
+		PyArrayObject *contig = PyArray_GETCONTIGUOUS(array);
+		ar & make_nvp("data_raw", binary_data((char*)PyArray_DATA(contig),
+						      PyArray_NBYTES(contig)));
+		Py_DECREF((PyObject*)contig);
+	} else {
+		struct flac_block *_flac = flac;
+		if (_flac == nullptr) {
+			// Encode to a copy.
+			_flac = new struct flac_block;
+			*_flac = encode_flac_bz2(options.data_algo, array, options.precision);
+		}
+
+		// Write the flacblock
+		ar & make_nvp("precision", _flac->precision);
+		ar & make_nvp("offsets", _flac->offsets);
+		ar & make_nvp("payload_bytes", _flac->count);
+		ar & make_nvp("payload", binary_data(_flac->buf, _flac->count));
+
+		if (_flac != flac) {
+			delete _flac->buf;
+			delete _flac;
+		}
+	}
 }
 
-bool G3SuperTimestream::Encode(float precision) {
+bool G3SuperTimestream::Encode() {
 	if (array == nullptr)
 		return false;
 
 	// Compress the array data.
-	flac = new struct flac_block;
-	*flac = encode_flac(array, precision);
-
-	Py_XDECREF(array);
-	array = nullptr;
-
+	if (options.data_algo == ALGO_NONE)
+		return false;
+	else {
+		flac = new struct flac_block;
+		*flac = encode_flac_bz2(options.data_algo, array, options.precision);
+		Py_XDECREF(array);
+		array = nullptr;
+	}
 	return true;
 }
 
@@ -182,7 +341,6 @@ struct flac_helper {
 	int bytes_remaining;
 	char *src;
 	char *dest;
-	int32_t pivot;
 	float precision;
 };
 
@@ -210,19 +368,7 @@ FLAC__StreamDecoderWriteStatus write_callback_int(
 	auto fh = (struct flac_helper *)client_data;
 	int n = frame->header.blocksize;
 	for (int i=0; i<n; i++)
-		((T*)fh->dest)[i] = buffer[0][i] + fh->pivot;
-	fh->dest += n * sizeof(T);
-	return FLAC__STREAM_DECODER_WRITE_STATUS_CONTINUE;
-}
-
-template <typename T>
-FLAC__StreamDecoderWriteStatus write_callback_float(
-	const FLAC__StreamDecoder *decoder, const FLAC__Frame *frame, const FLAC__int32 *const buffer[], void *client_data)
-{
-	auto fh = (struct flac_helper *)client_data;
-	int n = frame->header.blocksize;
-	for (int i=0; i<n; i++)
-		((T*)fh->dest)[i] = buffer[0][i] * fh->precision;
+		((T*)fh->dest)[i] = buffer[0][i];
 	fh->dest += n * sizeof(T);
 	return FLAC__STREAM_DECODER_WRITE_STATUS_CONTINUE;
 }
@@ -245,53 +391,107 @@ static void flac_decoder_error_cb(const FLAC__StreamDecoder *decoder,
 	}
 }
 
-bool G3SuperTimestream::Decode() {
-	/* printf("decode %p %p\n", array, flac); */
+template <typename T>
+void expand_branch(struct flac_helper *fh, int n_bytes, int nsamps,
+	char *temp)
+{
+	bool own_temp = (temp == nullptr);
+	unsigned int temp_size = nsamps * sizeof(T);
+	if (own_temp)
+		temp = new char[temp_size];
 
+	int err = BZ2_bzBuffToBuffDecompress(
+		temp, &temp_size, fh->src, n_bytes,
+		1, SO3G_BZ2_VERBOSITY);
+	if (err != BZ_OK)
+		throw g3supertimestream_exception(get_bz2_error_string(err));
+	// Add it in ...
+	for (int i=0; i<nsamps; i++)
+		((T*)fh->dest)[i] += ((T*)temp)[i];
+
+	if (own_temp)
+		delete temp;
+}
+
+bool G3SuperTimestream::Decode()
+{
 	if (flac == nullptr)
 		return false;
 
-	array = (PyArrayObject*)
-		PyArray_SimpleNew(desc.ndim, desc.shape, desc.type_num);
+	assert (options.data_algo != 0);
 
-	auto decoder = FLAC__stream_decoder_new();
+	FLAC__StreamDecoder *decoder = nullptr;
+	if (options.data_algo & ALGO_DO_FLAC)
+		decoder = FLAC__stream_decoder_new();
+	array = (PyArrayObject*)
+		PyArray_ZEROS(desc.ndim, desc.shape, desc.type_num, 0);
+
 	struct flac_helper helper;
 	helper.precision = flac->precision;
 
 	FLAC__StreamDecoderWriteCallback this_write_callback;
+	void (*expand_func)(struct flac_helper *, int, int, char*) = nullptr;
+	int elsize = 0;
+
 	switch (desc.type_num) {
 	case NPY_INT32:
+	case NPY_FLOAT32:
 		this_write_callback = &write_callback_int<int32_t>;
+		expand_func = expand_branch<int32_t>;
+		elsize = sizeof(int32_t);
 		break;
 	case NPY_INT64:
-		this_write_callback = &write_callback_int<int64_t>;
-		break;
-	case NPY_FLOAT32:
-		this_write_callback = &write_callback_float<float>;
-		break;
 	case NPY_FLOAT64:
-		this_write_callback = &write_callback_float<double>;
+		this_write_callback = &write_callback_int<int64_t>;
+		expand_func = expand_branch<int64_t>;
+		elsize = sizeof(int64_t);
 		break;
 	default:
 		throw g3supertimestream_exception("Invalid array type encountered.");
 	}
 
+	char *temp = new char[PyArray_SHAPE(array)[1] * elsize];
+
 	for (int i=0; i<desc.shape[0]; i++) {
-		helper.src = flac->buf + flac->offsets[i];
-		helper.bytes_remaining = flac->offsets[i+1] - flac->offsets[i];
-		helper.pivot = flac->pivots[i];
-		helper.dest = (char*)PyArray_DATA(array) + PyArray_STRIDES(array)[0]*i;
+		char* this_data = (char*)PyArray_DATA(array) + PyArray_STRIDES(array)[0]*i;
+		if (decoder != nullptr) {
+			helper.dest = this_data;
+			helper.src = flac->buf + flac->offsets[2*i];
+			helper.bytes_remaining = flac->offsets[2*i+1] - flac->offsets[2*i];
 
-		FLAC__stream_decoder_init_stream(
-			decoder, read_callback, NULL, NULL, NULL, NULL,
-			*this_write_callback, NULL, flac_decoder_error_cb,
-			(void*)&helper);
+			FLAC__stream_decoder_init_stream(
+				decoder, read_callback, NULL, NULL, NULL, NULL,
+				*this_write_callback, NULL, flac_decoder_error_cb,
+				(void*)&helper);
 
-		FLAC__stream_decoder_process_until_end_of_stream(decoder);
-		FLAC__stream_decoder_finish(decoder);
+			FLAC__stream_decoder_process_until_end_of_stream(decoder);
+			FLAC__stream_decoder_finish(decoder);
+		}
+
+		// And bz2 bit
+		if (options.data_algo & ALGO_DO_BZ) {
+			helper.src = flac->buf + flac->offsets[2*i+1];
+			helper.dest = this_data;
+			expand_func(&helper, flac->offsets[2*i+2] - flac->offsets[2*i+1],
+				    PyArray_SHAPE(array)[1], temp);
+		}
+
+		// Now convert for precision.
+		if (desc.type_num == NPY_FLOAT32) {
+			auto src = (int32_t*)this_data;
+			auto dest = (float*)this_data;
+			for (int j=0; j<PyArray_SHAPE(array)[1]; j++)
+				dest[j] = (float)src[j] * flac->precision;
+		} else if (desc.type_num == NPY_FLOAT64) {
+			auto src = (int64_t*)this_data;
+			auto dest = (double*)this_data;
+			for (int j=0; j<PyArray_SHAPE(array)[1]; j++)
+				dest[j] = src[j] * flac->precision;
+		}
 	}
-
-        FLAC__stream_decoder_delete(decoder);
+	delete temp;
+	if (decoder != nullptr)
+		FLAC__stream_decoder_delete(decoder);
 
 	// Destroy the flac bundle.
 	delete flac->buf;
@@ -299,6 +499,25 @@ bool G3SuperTimestream::Decode() {
 	flac = nullptr;
 
 	return true;
+}
+
+int G3SuperTimestream::Options(int data_algo, int times_algo, float precision)
+{
+	if (data_algo >= 0)
+		options.data_algo = data_algo;
+	if (times_algo >= 0)
+		options.times_algo = times_algo;
+	if (precision >= 0)
+		options.precision = precision;
+	return 0;
+}
+
+
+G3SuperTimestream::G3SuperTimestream() {
+	options.times_algo = ALGO_DO_BZ;
+	options.data_algo = ALGO_DO_FLAC | ALGO_DO_BZ;
+	array = nullptr;
+	flac = nullptr;
 }
 
 G3SuperTimestream::~G3SuperTimestream()
@@ -344,6 +563,8 @@ void safe_set_names(G3SuperTimestream &self, G3VectorString _names)
 static
 void safe_set_data(G3SuperTimestream &self, const bp::object object_in)
 {
+	// Note this function, as invoked here, might return a
+	// reference or create a new array.
 	PyObject *ob = PyArray_FromAny(object_in.ptr(), NULL, 0, 0, 0, NULL);
 	if (ob == NULL)
 		throw g3supertimestream_exception("Could not decode array.");
@@ -363,6 +584,11 @@ void safe_set_data(G3SuperTimestream &self, const bp::object object_in)
 		throw g3supertimestream_exception("Bad shape[1].");
 	}
 
+	// Clear cached array or compressed data.
+	if (self.array) {
+		Py_XDECREF((PyObject*)self.array);
+		self.array = nullptr;
+	}
 	if (self.flac) {
 		delete self.flac->buf;
 		delete self.flac;
@@ -372,7 +598,6 @@ void safe_set_data(G3SuperTimestream &self, const bp::object object_in)
 	self.desc.ndim = PyArray_NDIM(_array);
 	self.desc.type_num = PyArray_TYPE(_array);
 
-	self.desc.item_size = PyArray_ITEMSIZE(_array);
 	self.desc.nbytes = PyArray_NBYTES(_array);
 	for (int i=0; i<self.desc.ndim; i++)
 		self.desc.shape[i] = PyArray_DIMS(_array)[i];
@@ -418,6 +643,9 @@ PYBINDINGS("so3g")
 		.add_property("dtype", &safe_get_dtype, "Numpy dtype of underlying array.")
 		.def("encode", &G3SuperTimestream::Encode, "Compress.")
 		.def("decode", &G3SuperTimestream::Decode, "De-compress.")
+		.def("options", &G3SuperTimestream::Options,
+		     (bp::arg("data_algo")=-1, bp::arg("times_algo")=-1, bp::arg("precision")=-1.),
+		     "Get/set compression options.")
 		;
 	register_pointer_conversions<G3SuperTimestream>();
 

--- a/src/G3SuperTimestream.cxx
+++ b/src/G3SuperTimestream.cxx
@@ -333,6 +333,15 @@ bp::object safe_get_data(G3SuperTimestream &self)
 	return bp::object(bp::handle<>(bp::borrowed(reinterpret_cast<PyObject*>(self.array))));
 }
 
+static
+bp::object safe_get_dtype(G3SuperTimestream &self)
+{
+	if (self.array == nullptr)
+		return bp::object(); // not good enough...
+	return bp::object(bp::handle<>(bp::borrowed(reinterpret_cast<PyObject*>(
+							    PyArray_DESCR(self.array)->typeobj))));
+}
+
 
 G3_SPLIT_SERIALIZABLE_CODE(G3SuperTimestream);
 
@@ -351,6 +360,7 @@ PYBINDINGS("so3g")
 			      "Names vector.  Setting this stores a copy, but getting returns a reference.")
 		.add_property("data", &safe_get_data, &safe_set_data,
 			      "Data array.")
+		.add_property("dtype", &safe_get_dtype, "Numpy dtype of underlying array.")
 		.def("encode", &G3SuperTimestream::Encode, "Compress.")
 		.def("decode", &G3SuperTimestream::Decode, "De-compress.")
 		;

--- a/src/G3SuperTimestream.cxx
+++ b/src/G3SuperTimestream.cxx
@@ -228,6 +228,16 @@ bool G3SuperTimestream::Decode() {
 	return true;
 }
 
+G3SuperTimestream::~G3SuperTimestream()
+{
+	if (array != nullptr)
+		Py_XDECREF(array);
+	if (flac != nullptr) {
+		delete flac->buf;
+		delete flac;
+	}
+}
+
 static
 void safe_set_times(G3SuperTimestream &self, G3VectorTime _times)
 {

--- a/src/G3SuperTimestream.cxx
+++ b/src/G3SuperTimestream.cxx
@@ -1,0 +1,332 @@
+#define NO_IMPORT_ARRAY
+
+#include <pybindings.h>
+
+/* #include <numeric> */
+/* #include <algorithm> */
+#include <iostream>
+#include <boost/python.hpp>
+
+#include <container_pybindings.h>
+#include <G3SuperTimestream.h>
+#include <cereal/types/utility.hpp>
+
+#include <FLAC/stream_encoder.h>
+
+
+FLAC__StreamEncoderWriteStatus flac_encoder_write_cb(
+	const FLAC__StreamEncoder *encoder,
+	const FLAC__byte buffer[],
+	size_t bytes,
+	unsigned samples,
+	unsigned current_frame,
+	void *client_data)
+{
+	auto fb = (struct G3SuperTimestream::flac_block *)client_data;
+	assert(bytes + fb->count <= fb->size);
+	memcpy(fb->buf + fb->count, buffer, bytes);
+	fb->count += bytes;
+	return FLAC__STREAM_ENCODER_WRITE_STATUS_OK;
+}
+
+
+static
+struct G3SuperTimestream::flac_block encode_flac(PyArrayObject *array)
+{
+	struct G3SuperTimestream::flac_block fb;
+	int n = PyArray_NBYTES(array);
+
+	fb.buf = new char[n];
+	fb.size = n;
+	fb.count = 0;
+	fb.offsets.push_back(0);
+
+	char *d = (char*)(PyArray_DATA(array));
+	const int32_t *chan_ptrs[1];
+	FLAC__StreamEncoder *encoder = FLAC__stream_encoder_new();
+
+	for (int i=0; i< PyArray_DIMS(array)[0]; i++, d+=PyArray_STRIDES(array)[0]) {
+		FLAC__stream_encoder_set_channels(encoder, 1);
+		FLAC__stream_encoder_set_bits_per_sample(encoder, 24);
+		FLAC__stream_encoder_set_compression_level(encoder, 1);
+
+		FLAC__stream_encoder_init_stream(
+			encoder, flac_encoder_write_cb, NULL, NULL, NULL, (void*)(&fb));
+		chan_ptrs[0] = (int32_t*)d;
+		FLAC__stream_encoder_process(encoder, chan_ptrs, PyArray_DIMS(array)[1]);
+		FLAC__stream_encoder_finish(encoder);
+		fb.offsets.push_back(fb.count);
+	}
+	FLAC__stream_encoder_delete(encoder);
+
+	return fb;
+}
+
+
+/* G3SuperTimestream */
+
+std::string G3SuperTimestream::Description() const
+{
+	std::ostringstream s;
+	s << "G3SuperTimestream("
+	  << names.size() << ", " << times.size() << ")";
+	return s.str();
+}
+
+std::string G3SuperTimestream::Summary() const
+{
+	return Description();
+}
+
+template <class A> void G3SuperTimestream::load(A &ar, unsigned v)
+{
+	using namespace cereal;
+	ar & make_nvp("parent", base_class<G3FrameObject>(this));
+	ar & make_nvp("times", times);
+	ar & make_nvp("names", names);
+
+	// Read the desc.
+        ar & make_nvp("type_num", desc.type_num);
+        ar & make_nvp("ndim", desc.ndim);
+	ar & make_nvp("shape", desc.shape);
+        ar & make_nvp("item_size", desc.item_size);
+        ar & make_nvp("nbytes", desc.nbytes);
+
+	// Read the flacblock
+	flac = new struct flac_block;
+	ar & make_nvp("payload_bytes", flac->count);
+	ar & make_nvp("offsets", flac->offsets);
+	flac->buf = new char[flac->count];
+	ar & make_nvp("payload", binary_data(flac->buf, flac->count));
+}
+
+template <class A> void G3SuperTimestream::save(A &ar, unsigned v) const
+{
+	using namespace cereal;
+	ar & make_nvp("parent", base_class<G3FrameObject>(this));
+	ar & make_nvp("times", times);
+	ar & make_nvp("names", names);
+
+	struct flac_block *_flac = flac;
+	if (_flac == nullptr) {
+		// Encode to a copy.
+		_flac = new struct flac_block;
+		*_flac = encode_flac(array);
+        }
+
+	// Write the desc.
+        ar & make_nvp("type_num", desc.type_num);
+        ar & make_nvp("ndim", desc.ndim);
+	ar & make_nvp("shape", desc.shape);
+        ar & make_nvp("item_size", desc.item_size);
+        ar & make_nvp("nbytes", desc.nbytes);
+
+	// Write the flacblock
+	//ar & make_nvp("codec", 1);
+	ar & make_nvp("payload_bytes", _flac->count);
+	ar & make_nvp("offsets", _flac->offsets);
+	ar & make_nvp("payload", binary_data(_flac->buf, _flac->count));
+}
+
+bool G3SuperTimestream::Encode(int codec) {
+	if (array == nullptr)
+		return false;
+
+	// Compress the array data.
+	flac = new struct flac_block;
+	*flac = encode_flac(array);
+
+	Py_XDECREF(array);
+	array = nullptr;
+
+	return true;
+}
+
+struct flac_helper {
+	int bytes_remaining;
+	char *src;
+	int32_t *dest;
+};
+
+FLAC__StreamDecoderReadStatus read_callback(
+	const FLAC__StreamDecoder *decoder, FLAC__byte buffer[], size_t *bytes, void *client_data)
+{
+	auto fh = (struct flac_helper *)client_data;
+	/* printf(" ... read %i (remaining: %i)\n", *bytes, fh->bytes_remaining); */
+	if (fh->bytes_remaining == 0) {
+		*bytes = 0;
+		return FLAC__STREAM_DECODER_READ_STATUS_END_OF_STREAM;
+	}
+	if (fh->bytes_remaining < *bytes)
+		*bytes = fh->bytes_remaining;
+	memcpy(buffer, fh->src, *bytes);
+	fh->bytes_remaining -= *bytes;
+	fh->src += *bytes;
+	return FLAC__STREAM_DECODER_READ_STATUS_CONTINUE;
+}
+
+FLAC__StreamDecoderWriteStatus write_callback(
+	const FLAC__StreamDecoder *decoder, const FLAC__Frame *frame, const FLAC__int32 *const buffer[], void *client_data)
+{
+	auto fh = (struct flac_helper *)client_data;
+	int n = frame->header.blocksize;
+	memcpy(fh->dest, buffer[0], n * sizeof(int32_t));
+	fh->dest += n;
+	return FLAC__STREAM_DECODER_WRITE_STATUS_CONTINUE;
+}
+
+static void flac_decoder_error_cb(const FLAC__StreamDecoder *decoder,
+				  FLAC__StreamDecoderErrorStatus status, void *client_data)
+{
+
+	switch (status) {
+	case FLAC__STREAM_DECODER_ERROR_STATUS_LOST_SYNC:
+		printf("FLAC decoding error (lost sync)");
+	case FLAC__STREAM_DECODER_ERROR_STATUS_BAD_HEADER:
+		printf("FLAC decoding error (bad header)");
+	case FLAC__STREAM_DECODER_ERROR_STATUS_FRAME_CRC_MISMATCH:
+		printf("FLAC decoding error (CRC mismatch)");
+	case FLAC__STREAM_DECODER_ERROR_STATUS_UNPARSEABLE_STREAM:
+		printf("FLAC decoding error (unparseable stream)");
+	default:
+		printf("FLAC decoding error (%d)", status);
+	}
+}
+
+bool G3SuperTimestream::Decode() {
+	/* printf("decode %p %p\n", array, flac); */
+
+	if (flac == nullptr)
+		return false;
+
+	array = (PyArrayObject*)
+		PyArray_SimpleNew(desc.ndim, desc.shape, desc.type_num);
+
+	auto decoder = FLAC__stream_decoder_new();
+
+	for (int i=0; i<desc.shape[0]; i++) {
+		struct flac_helper helper;
+		helper.src = flac->buf + flac->offsets[i];
+		helper.bytes_remaining = flac->offsets[i+1] - flac->offsets[i];
+		helper.dest = (int32_t*)PyArray_DATA(array) + desc.shape[1] * i;
+
+		FLAC__stream_decoder_init_stream(
+			decoder, read_callback, NULL, NULL, NULL, NULL,
+			write_callback, NULL, flac_decoder_error_cb, (void*)&helper);
+
+		FLAC__stream_decoder_process_until_end_of_stream(decoder);
+		FLAC__stream_decoder_finish(decoder);
+	}
+
+        FLAC__stream_decoder_delete(decoder);
+
+	// Kill the flac bundle.
+	delete flac->buf;
+	delete flac;
+	flac = nullptr;
+
+	return true;
+}
+
+static
+void safe_set_times(G3SuperTimestream &self, G3VectorTime _times)
+{
+	// Only allow this if it doesn't upset consistency.  We will
+	// assume that, coming in, we're internally consistent.
+	if (_times.size() != self.times.size() && self.times.size() != 0) {
+		std::ostringstream s;
+		s << "Cannot set .times because it conflicts with "
+		  << "the established number of samples (" << self.times.size()
+		  << ").";
+		throw g3supertimestream_exception(s.str());
+	}
+	self.times = _times;
+}
+
+static
+void safe_set_names(G3SuperTimestream &self, G3VectorString _names)
+{
+	// Only allow this if it doesn't upset consistency.  We will
+	// assume that, coming in, we're internally consistent.
+	if (_names.size() != self.names.size() && self.names.size() != 0) {
+		std::ostringstream s;
+		s << "Cannot set .names because it conflicts with "
+		  << "the established number of channels (" << self.names.size()
+		  << ").";
+		throw g3supertimestream_exception(s.str());
+	}
+	self.names = _names;
+}
+
+static
+void safe_set_data(G3SuperTimestream &self, const bp::object object_in)
+{
+	PyObject *ob = PyArray_FromAny(object_in.ptr(), NULL, 0, 0, 0, NULL);
+	if (ob == NULL)
+		throw g3supertimestream_exception("Could not decode array.");
+
+	PyArrayObject *_array = reinterpret_cast<PyArrayObject*>(ob);
+
+	if (PyArray_NDIM(_array) != 2) {
+		Py_XDECREF(ob);
+		throw g3supertimestream_exception("Bad ndim.");
+	}
+	if (PyArray_DIMS(_array)[0] != self.names.size()) {
+		Py_XDECREF(ob);
+		throw g3supertimestream_exception("Bad shape[0].");
+	}
+	if (PyArray_DIMS(_array)[1] != self.times.size()) {
+		Py_XDECREF(ob);
+		throw g3supertimestream_exception("Bad shape[1].");
+	}
+
+	if (self.flac) {
+		delete self.flac->buf;
+		delete self.flac;
+		self.flac = nullptr;
+	}
+
+	self.desc.ndim = PyArray_NDIM(_array);
+	self.desc.type_num = PyArray_TYPE(_array);
+
+	self.desc.item_size = PyArray_ITEMSIZE(_array);
+	self.desc.nbytes = PyArray_NBYTES(_array);
+	for (int i=0; i<self.desc.ndim; i++)
+		self.desc.shape[i] = PyArray_DIMS(_array)[i];
+
+	self.array = _array;
+}
+
+static
+bp::object safe_get_data(G3SuperTimestream &self)
+{
+	if (self.array == nullptr)
+		self.Decode();
+	return bp::object(bp::handle<>(bp::borrowed(reinterpret_cast<PyObject*>(self.array))));
+}
+
+
+G3_SPLIT_SERIALIZABLE_CODE(G3SuperTimestream);
+
+static void translate_ValueError(g3supertimestream_exception const& e)
+{
+	PyErr_SetString(PyExc_ValueError, e.msg_for_python().c_str());
+}
+
+
+PYBINDINGS("so3g")
+{
+	EXPORT_FRAMEOBJECT(G3SuperTimestream, init<>(), "G3SuperTimestream()")
+		.add_property("times", &G3SuperTimestream::times, &safe_set_times,
+			      "Times vector.  Setting this stores a copy, but getting returns a reference.")
+		.add_property("names", &G3SuperTimestream::names, &safe_set_names,
+			      "Names vector.  Setting this stores a copy, but getting returns a reference.")
+		.add_property("data", &safe_get_data, &safe_set_data,
+			      "Data array.")
+		.def("encode", &G3SuperTimestream::Encode, "Compress.")
+		.def("decode", &G3SuperTimestream::Decode, "De-compress.")
+		;
+	register_pointer_conversions<G3SuperTimestream>();
+
+	bp::register_exception_translator<g3supertimestream_exception>(&translate_ValueError);
+}

--- a/test/test_g3super.py
+++ b/test/test_g3super.py
@@ -1,4 +1,5 @@
 import unittest
+import time
 
 import numpy as np
 import so3g
@@ -79,3 +80,21 @@ class TestSuperTimestream(unittest.TestCase):
         r = core.G3Reader(test_file)
         ts2 = r.Process(None)[0]['a']
         self._check_equal(ts, ts2)
+
+
+def offline_test_memory_leak(MB_per_second=100, encode=True, decode=True):
+    """Memory leak loop ... not intended for automated testing!"""
+    helper = TestSuperTimestream()
+    tick_time = .5
+    next_tick = time.time()
+    while True:
+        d = time.time() - next_tick
+        if d < 0:
+            time.sleep(d)
+        next_tick += tick_time
+        print(' ... tick.')
+        ts = helper._get_ts(100, int(10000 * MB_per_second * tick_time / 4))
+        if encode:
+            ts.encode(1)
+            if decode:
+                ts.decode()

--- a/test/test_g3super.py
+++ b/test/test_g3super.py
@@ -1,0 +1,81 @@
+import unittest
+
+import numpy as np
+import so3g
+from spt3g import core
+
+
+class TestSuperTimestream(unittest.TestCase):
+
+    def _get_ts(self, nchans, ntimes, sigma=256):
+        chans = ['x%i' % i for i in range(nchans)]
+        times = core.G3VectorTime(
+            (1680000000 + np.arange(ntimes) * .005) * core.G3Units.s)
+        data = (np.random.normal(size=(len(chans), len(times))) * sigma).astype('int32')
+        ts = so3g.G3SuperTimestream()
+        ts.times = times
+        ts.names = chans
+        ts.data = data
+        return ts
+
+    def _check_equal(self, ts1, ts2):
+        np.testing.assert_array_equal(ts1.data, ts2.data)
+        np.testing.assert_array_equal(np.array(ts1.times), np.array(ts2.times))
+        np.testing.assert_array_equal(np.array(ts1.names), np.array(ts2.names))
+
+    def test_00_basic(self):
+        times = core.G3VectorTime((1680000000 + np.arange(10000)) * core.G3Units.s)
+        chans = ['a', 'b', 'c', 'd', 'e']
+        data = np.zeros((len(chans), len(times)), dtype='int32')
+
+        ts = so3g.G3SuperTimestream()
+        ts.times = times
+        ts.names = chans
+        ts.data = data
+
+        with self.assertRaises(ValueError):
+            ts.times = times[:-1]
+
+        with self.assertRaises(ValueError):
+            ts.names = chans[:-1]
+
+        ts = so3g.G3SuperTimestream()
+        with self.assertRaises(ValueError):
+            ts.data = data
+
+        ts = so3g.G3SuperTimestream()
+        ts.names = chans
+        with self.assertRaises(ValueError):
+            ts.data = data
+
+        ts = so3g.G3SuperTimestream()
+        ts.times = times
+        with self.assertRaises(ValueError):
+            ts.data = data
+
+        ts = so3g.G3SuperTimestream()
+        ts.names = chans
+        ts.times = times
+        with self.assertRaises(ValueError):
+            ts.data = data[1:]
+        with self.assertRaises(ValueError):
+            ts.data = data[:,:-1]
+
+    def test_10_encode(self):
+        ts = self._get_ts(200, 10000)
+        d1 = ts.data.copy()
+        ts.encode(1)
+        np.testing.assert_array_equal(d1, ts.data)
+
+    def test_20_serialize(self):
+        ts = self._get_ts(200, 10000)
+        ts.encode(1)
+        test_file = 'test_g3super.g3'
+        w = core.G3Writer(test_file)
+        f = core.G3Frame()
+        f['a'] = ts
+        w.Process(f)
+        del w
+        r = core.G3Reader(test_file)
+        ts2 = r.Process(None)[0]['a']
+        self._check_equal(ts, ts2)

--- a/test/test_g3super.py
+++ b/test/test_g3super.py
@@ -6,18 +6,19 @@ import so3g
 from spt3g import core
 
 
+INT_DTYPES = ['int32', 'int64']
+FLOAT_DTYPES = ['float32', 'float64']
+ALL_DTYPES = INT_DTYPES + FLOAT_DTYPES
+
+
 class TestSuperTimestream(unittest.TestCase):
 
     def test_00_dtypes(self):
-        times = core.G3VectorTime((1680000000 + np.arange(1000)) * core.G3Units.s)
-        names = ['a', 'b', 'c', 'd', 'e']
-
-        for dtype in ['int32', 'int64', 'float32', 'float64']:
+        for dtype in ALL_DTYPES:
             ts = self._get_ts(4, 100, sigma=0, dtype=dtype)
-            ts.encode(1.)
+            ts.encode()
             ts.decode()
             assert(ts.data.dtype is np.dtype(dtype))
-            #assert(ts.dtype is np.dtype(dtype))
 
     def test_01_consistency(self):
         """Test that concordance of (times, names, data) is enforced."""
@@ -55,60 +56,127 @@ class TestSuperTimestream(unittest.TestCase):
             ts.data = data[:,:-1]
 
     def test_10_encode_int(self):
-        ts = self._get_ts(200, 10000)
-        d1 = ts.data.copy()
-        ts.encode(1)
-        np.testing.assert_array_equal(d1, ts.data)
-
-        # Test with a few offsets...
-        for offset in [2**25, 2**26 / 3., -1.78 * 2**27]:
-            ts = self._get_ts(200, 10000)
-            ts.data += int(offset)
+        for dtype in INT_DTYPES:
+            err_msg = f'Failure during test of dtype={dtype}'
+            ts = self._get_ts(10, 980, dtype=dtype)
             d1 = ts.data.copy()
-            ts.encode(1)
-            np.testing.assert_array_equal(d1, ts.data)
+            ts.encode()
+            np.testing.assert_array_equal(d1, ts.data, err_msg=err_msg)
+
+            # Test with a few offsets...
+            for offset in [2**25, 2**26 / 3., -1.78 * 2**27]:
+                ts = self._get_ts(10, 980)
+                ts.data += int(offset)
+                d1 = ts.data.copy()
+                ts.encode()
+                np.testing.assert_array_equal(d1, ts.data, err_msg=err_msg)
 
     def test_20_encode_float(self):
-        for dtype in ['float32', 'float64']:
-            ts = self._get_ts(200, 10000, sigma=5., dtype=dtype)
+        for dtype in FLOAT_DTYPES:
+            err_msg = f'Failure during test of dtype={dtype}'
+            ts = self._get_ts(9, 1290, sigma=5., dtype=dtype)
             decimals = 2
-            precision = 10**(-decimals)
+            precision=10**-decimals
             ts.data[:] = np.round(ts.data, decimals)
             d1 = ts.data.copy()
-            ts.encode(10**(-decimals))
-            np.testing.assert_allclose(d1, ts.data, atol=precision*1e-3)
+            ts.options(precision=precision)
+            ts.encode()
+            np.testing.assert_allclose(d1, ts.data, atol=precision*1e-3,
+                                       err_msg=err_msg)
 
-    def test_30_serialize(self):
+    def test_40_encoding_serialized(self):
         test_file = 'test_g3super.g3'
-        ts = self._get_ts(200, 10000)
+        offsets = {
+            'int32': [0, 2**25, 2**26 / 3., -1.78 * 2**27],
+            'int64': [0, 2**25, 2**26 / 3., -1.78 * 2**27],
+            'float32': [0],
+            'float64': [0, 2**25, 2**26 / 3., -1.78 * 2**27, 1.8*2**35],
+        }
+        decimals = 2
+        precision=10**-decimals
 
         w = core.G3Writer(test_file)
-        f = core.G3Frame()
-        f['a'] = ts
-        w.Process(f)
-        del w
-        r = core.G3Reader(test_file)
-        ts2 = r.Process(None)[0]['a']
-        self._check_equal(ts, ts2)
-
-        offsets = [0, 2**25, 2**26 / 3., -1.78 * 2**27]
         records = []
+        for dtype in ALL_DTYPES:
+            for offset in offsets[dtype]:
+                f = core.G3Frame()
+                ts = self._get_ts(4, 100, sigma=100, dtype=dtype)
+                ts.data += int(offset)
+                if dtype in FLOAT_DTYPES:
+                    ts.options(precision=precision)
+                    ts.data[:] = ts.data.round(decimals)
+                records.append(ts.data.copy())
+                f['a'] = ts
+                w.Process(f)
+        del w
+        # readback
+        r = core.G3Reader(test_file)
+        for dtype in ALL_DTYPES:
+            for offset in offsets[dtype]:
+                err_msg = f'Failed for dtype={dtype}, offset={offset}'
+                ts2 = r.Process(None)[0]['a']
+                record = records.pop(0)
+                np.testing.assert_allclose(record, ts2.data,
+                                           atol=precision*1e-3, err_msg=err_msg)
+
+    def test_50_compression(self):
+        test_file = 'test_g3super.g3'
+
+        # Entropy?
+        sigma_bits = 8
+        sigma = 2**sigma_bits
+        _get_ts = lambda dtype: self._get_ts(100, 10000, sigma=sigma, dtype=dtype, seed=12345)
+
         w = core.G3Writer(test_file)
-        for offset in offsets:
+
+        sizes = {d: [] for d in ALL_DTYPES}
+        for dtype in ALL_DTYPES:
+            # No compression
             f = core.G3Frame()
-            ts.data += int(offset)
-            records.append(ts.data.copy())
-            f['a'] = ts
+            ts = _get_ts(dtype)
+            sizes[dtype].append(ts.data.nbytes)
+            if dtype in FLOAT_DTYPES:
+                ts.options(precision=1.0)
+            ts.options(data_algo=0, times_algo=0)
+            f['ts_%s' % dtype] = ts
+            w.Process(f)
+
+            # Yes compression
+            f = core.G3Frame()
+            ts = _get_ts(dtype)
+            if dtype in FLOAT_DTYPES:
+                ts.options(precision=1.0)
+            ts.options(times_algo=0)
+            f['ts_%s' % dtype] = ts
             w.Process(f)
         del w
-        r = core.G3Reader(test_file)
-        for offset, record in zip(offsets, records):
-            ts2 = r.Process(None)[0]['a']
-            np.testing.assert_array_equal(record, ts2.data)
+
+        # Readback
+        r = so3g.G3IndexedReader(test_file)
+        last = 0
+        for dtype in ALL_DTYPES:
+            for i in range(2):
+                r.Process(None)[0]
+                here = r.Tell()
+                sizes[dtype].append(here - last)
+                last = here
+
+        # Process the results...
+        for dtype in ALL_DTYPES:
+            err_msg = f'Failed for dtype={dtype}'
+            n, s_uncomp, s_comp = sizes[dtype]
+            comp_ratio = 1. - (s_uncomp - s_comp) / n
+            # But really what matters is the bits-per-word, compressed.
+            bits_per_word = comp_ratio * 8 * np.dtype(dtype).itemsize
+            #print(dtype, bits_per_word / sigma_bits)
+            # I think the theoretical limit is 1.3 or so...
+            self.assertLess(bits_per_word, sigma_bits * 1.4, err_msg)
 
     # Support functions
 
-    def _get_ts(self, nchans, ntimes, sigma=256, dtype='int32', raw=False):
+    def _get_ts(self, nchans, ntimes, sigma=256, dtype='int32', raw=False, seed=None):
+        if seed is not None:
+            np.random.seed(seed)
         names = ['x%i' % i for i in range(nchans)]
         times = core.G3VectorTime(
             (1680000000 + np.arange(ntimes) * .005) * core.G3Units.s)


### PR DESCRIPTION
G3SuperTimestream supports compressed storage of 2d arrays, especially those carrying noisy time-ordered data.

This is in an advanced state, so posting for comment / testing.  Compression works and it's not totally awful.

This PR is a draft, for now, because:
- The approach to floats isn't right, yet.  The idea that a single "precision" can be applied to all data is good for sims but bad for real data, where individual calibration factors for each detector will introduce a different natural "precision", and any compromise precision could induce odd rounding artifacts.
- There isn't a convenient C++ interface for adding .data (making it difficult to integrate into the streamer).
- Haven't checked for memory leaks lately...
