### PR TITLE
Fixes to support tiled mapmaking

### DIFF
--- a/demos/demo_proj1.py
+++ b/demos/demo_proj1.py
@@ -166,7 +166,7 @@ if 1:
 
 print('Compute thread assignments (OMP prep)... ', end='\n ... ')
 with Timer():
-    threads = pe.pixel_ranges(ptg, ofs, None)
+    threads = pe.pixel_ranges(ptg, ofs, None, -1)
 
 if 1:
     print('TOD-to-map with OMP (%s): ' % n_omp, end='\n ... ')

--- a/include/Projection.h
+++ b/include/Projection.h
@@ -46,6 +46,8 @@ public:
     bp::object coords(bp::object pbore, bp::object pofs,
                       bp::object coord);
     bp::object pixels(bp::object pbore, bp::object pofs, bp::object pixel);
+    vector<int> tile_hits(bp::object pbore, bp::object pofs);
+    bp::object tile_ranges(bp::object pbore, bp::object pofs, bp::object tile_lists);
     bp::object pointing_matrix(bp::object pbore, bp::object pofs,
                                bp::object pixel, bp::object proj);
     bp::object zeros(bp::object shape);

--- a/include/Projection.h
+++ b/include/Projection.h
@@ -51,7 +51,7 @@ public:
     bp::object pointing_matrix(bp::object pbore, bp::object pofs,
                                bp::object pixel, bp::object proj);
     bp::object zeros(bp::object shape);
-    bp::object pixel_ranges(bp::object pbore, bp::object pofs, bp::object map);
+    bp::object pixel_ranges(bp::object pbore, bp::object pofs, bp::object map, int n_domain=-1);
     bp::object from_map(bp::object map, bp::object pbore, bp::object pofs,
                         bp::object signal);
     bp::object to_map(bp::object map, bp::object pbore, bp::object pofs,

--- a/include/exceptions.h
+++ b/include/exceptions.h
@@ -77,6 +77,21 @@ public:
     }
 };
 
+class tiling_exception : public so3g_exception
+{
+public:
+    int tile_idx;
+    std::string msg;
+    tiling_exception(int tile_idx, std::string msg) :
+        tile_idx{tile_idx}, msg{msg} {}
+
+    std::string msg_for_python() const throw() {
+        std::ostringstream s;
+        s << "Tiling problem (index " << tile_idx << "): " << msg;
+        return s.str();
+    }
+};
+
 class general_agreement_exception : public so3g_exception
 {
 public:

--- a/python/proj/mapthreads.py
+++ b/python/proj/mapthreads.py
@@ -12,8 +12,9 @@ def get_num_threads(n_threads=None):
     return n_threads
 
 
-def get_threads_domdir(sight, offs, shape, wcs, n_threads=None,
-                       offs_rep=None, plot_prefix=None):
+def get_threads_domdir(sight, offs, shape, wcs, tile_shape=None,
+                       active_tiles=None,
+                       n_threads=None, offs_rep=None, plot_prefix=None):
     """Assign samples to threads according to the dominant scan
     direction.
 
@@ -22,7 +23,12 @@ def get_threads_domdir(sight, offs, shape, wcs, n_threads=None,
       offs (array of quaternions): The detector pointing.
       shape (tuple): The map shape.
       wcs (wcs): The map WCS.
-      n_threads (int): The number of threads to target.
+      tile_shape (tuple): The tile shape, if this should be done using
+        tiles.
+      active_tiles (list): The list of active tiles.  If None, this
+        will be computed along the way.
+      n_threads (int): The number of threads to target (defaults to
+        OMP_NUM_THREADS).
       offs_rep (array of quaternions): A representative set of
         detectors, for determining scan direction and relative weights
         (if not present then offs is used for this).
@@ -34,81 +40,135 @@ def get_threads_domdir(sight, offs, shape, wcs, n_threads=None,
       passes as the "threads" argument to Projectionist routines.
 
     """
-    n_threads = get_num_threads(n_threads)
     if plot_prefix:
         import pylab as pl
+        if tile_shape is None:
+            tile_iter = lambda maps: [('', maps[0])]
+        else:
+            tile_iter = lambda maps: [('_tile%04i' % i, _m)
+                                      for i, _m in enumerate(maps)
+                                      if _m is not None]
+
+    n_threads = get_num_threads(n_threads)
     if offs_rep is None:
         offs_rep = offs
 
+    if tile_shape is None:
+        # Let's pretend it is, though; this simplifies logic below and
+        # doesn't cost much.
+        tile_shape = shape
+        active_tiles = [0]
+
+    # The full assembly, for later.
+    asm_full = so3g.proj.Assembly.attach(sight, offs)
+
+    # Get a Projectionist -- note it can be used with full or
+    # representative assembly.
+    pmat = so3g.proj.wcs.Projectionist.for_tiled(shape, wcs, tile_shape=tile_shape)
+    if active_tiles is None:
+        # This is OMPed, but it's still better to pass in active_tiles
+        # if you've already computed it somehow.
+        active_tiles = pmat.get_active_tiles(asm_full)['active_tiles']
+    pmat.active_tiles = active_tiles
+    tiling = pmat.tiling
+
+    # For the scan direction map, use the "representative" subset
+    # detectors, with polarization direction aligned parallel to
+    # elevation.
     xi, eta, gamma = so3g.proj.quat.decompose_xieta(offs_rep)
-    # Align the alternative detectors parallel to lines of constant el.
     offs_xl = np.array(so3g.proj.quat.rotation_xieta(xi, eta, gamma*0 + 90*so3g.proj.DEG))
-    pmat   = so3g.proj.wcs.Projectionist.for_geom(shape, wcs)
-    ass    = so3g.proj.Assembly.attach(sight, offs_xl)
+    asm_rep = so3g.proj.Assembly.attach(sight, offs_xl)
+    sig = np.ones((len(offs_xl), len(asm_rep.Q)), dtype='float32')
+    scan_maps = pmat.to_map(sig, asm_rep, comps='TQU')
 
-    sig = np.ones((len(offs_xl), len(ass.Q)), dtype='float32')
-    m = pmat.to_map(sig, ass, comps='TQU')
-    del sig
-
-    # Dominant angle?  This assumes that +Q is parallel to map
-    # columns, and U increases along the map diagonal.
-    T, Q, U = [_m.sum() for _m in m]
+    # Compute the scan angle, based on Q and U weights.  This assumes
+    # that +Q is parallel to map columns, and U increases along the
+    # map diagonal.
+    T, Q, U = np.sum([_m.reshape((3, -1)).sum(axis=-1)
+                      for _m in scan_maps if _m is not None], axis=0)
     phi = np.arctan2(U, Q) / 2
 
     if plot_prefix:
         text = 'Qf=%.2f Uf=%.2f phi=%.1f deg' % (Q/T, U/T, phi / so3g.proj.DEG)
-        for i in range(3):
-            pl.imshow(m[i], origin='lower')
-            pl.title('TQU'[i] + ' ' + text)
+        for label, _m in tile_iter(scan_maps):
+            for i in range(3):
+                pl.imshow(_m[i], origin='lower')
+                pl.title(label + ' '  + 'TQU'[i] + ' ' + text)
+                pl.colorbar()
+                pl.savefig(plot_prefix + '%02i%s%s.png' % (i, 'TQU'[i], label))
+                pl.clf()
+
+    # Now paint a map with a single parameter such that contours are
+    # parallel to the scan direction.
+    idx_maps = pmat.zeros((1,))
+    lims = None
+    for t in active_tiles:
+        y0, x0 = tiling.tile_offset(t)
+        ny, nx = tiling.tile_dims(t)
+        y, x = y0 + np.arange(ny), x0 + np.arange(nx)
+        idx_maps[t] = y[:,None]*np.sin(phi) - x[None,:]*np.cos(phi)
+        _lo, _hi = idx_maps[t].min(), idx_maps[t].max()
+        if lims is None:
+            lims = _lo, _hi
+        else:
+            lims = min(_lo, lims[0]), max(_hi, lims[1])
+
+    if plot_prefix:
+        for label, _m in tile_iter(idx_maps):
+            pl.imshow(_m, origin='lower')
             pl.colorbar()
-            pl.savefig(plot_prefix + '%02i.png' % i)
+            pl.savefig(plot_prefix + '10param%s.png' % label)
             pl.clf()
 
-    # Index the map in stripes parallel to phi
-    y, x = np.arange(m.shape[-2]), np.arange(m.shape[-1])
-    idx = y[:,None]*np.sin(phi) - x[None,:]*np.cos(phi)
+    # Histogram the parameter, weighted by the weights map -- this
+    # tells us the number of hits for ranges of the parameter value.
+    n_bins = 200
+    bins = np.linspace(lims[0], lims[1], n_bins+1)
+    H = np.zeros(n_bins)
+    for t in active_tiles:
+        H += np.histogram(idx_maps[t].ravel(), bins=bins,
+                          weights=scan_maps[t][0].ravel())[0]
+    del scan_maps
+
+    # Turn histogram into a CDF.  The CDF is non-decreasing, but could
+    # have some flat parts in it, so bias the whole curve to guarantee
+    # it's strictly increasing.
+    H = np.hstack((0, H.cumsum()))
+    bias = .00001
+    H = H / H.max() * (1-bias) + np.linspace(0, bias, len(H))
+
+    # Create n_threads "super_bins" that contain roughly equal weight.
+    xs = np.linspace(0, 1, n_threads + 1)
+    ys = np.interp(xs, H, bins)
+    superbins = np.hstack((bins[0], ys[1:-1], bins[-1]))
+
+    # Create maps where the pixel value is a superbin index.
+    for t in active_tiles:
+        temp = np.zeros(idx_maps[t].shape)
+        for i in range(n_threads):
+            s = (superbins[i] <= idx_maps[t])*(idx_maps[t] < superbins[i+1])
+            temp[s] = i
+        idx_maps[t][:] = temp
+        idx_maps[t].shape = (1, ) + tuple(idx_maps[t].shape)
+
+    # Turn the superbin index maps into thread assignments.
+    threads = pmat.assign_threads_from_map(asm_full, idx_maps)
 
     if plot_prefix:
-        pl.imshow(idx, origin='lower')
-        pl.colorbar()
-        pl.savefig(plot_prefix + '10.png')
+        pl.plot(bins, H)
+        for _x, _y in zip(superbins[1:-1], xs[1:-1]):
+            pl.plot([_x, _x], [-1, _y], c='k')
+            pl.plot([superbins[0], superbins[-1]], [_y, _y], c='gray')
+        pl.xlim(superbins[0], superbins[-1])
+        pl.ylim(-.01, 1.01)
+        pl.savefig(plot_prefix + '20histo.png')
         pl.clf()
 
-    # Bins.
-    n_bins = 100
-    bins = np.linspace(idx.min(), idx.max(), n_bins+1)
-    H, _ = np.histogram(idx.ravel(), weights=m[0].ravel(), bins=bins)
-    H = H.cumsum()
-    H /= H.max()
-
-    # Threadify.
-    superbins = [bins[0]]
-    for i in range(1, n_threads):
-        j = (H * n_threads >= i).nonzero()[0][0]
-        superbins.append(bins[j])
-
-    superbins.append(bins[-1])
-
-    # Convert the idx map.
-    tidx_map = np.zeros(idx.shape)
-    for i in range(n_threads):
-        s = (superbins[i] <= idx)*(idx < superbins[i+1])
-        tidx_map[s] = i
-
-    # Turn that into threads!    
-    ass    = so3g.proj.Assembly.attach(sight, offs)
-    threads = pmat.assign_threads_from_map(ass, tidx_map[None])
-
-    if plot_prefix:
-        pl.plot(bins[:-1], H)
-        for b in superbins[1:-1]:
-            pl.axvline(b)
-        pl.savefig(plot_prefix + '12.png')
-        pl.clf()
-        pl.imshow(tidx_map, origin='lower')
-        pl.colorbar()
-        pl.savefig(plot_prefix + '13.png')
-        pl.clf()
+        for label, _m in tile_iter(idx_maps):
+            pl.imshow(_m[0], origin='lower')
+            pl.colorbar()
+            pl.savefig(plot_prefix + '30thread%s.png' % label)
+            pl.clf()
 
     return threads
 

--- a/python/proj/mapthreads.py
+++ b/python/proj/mapthreads.py
@@ -169,7 +169,7 @@ def get_threads_domdir(sight, offs, shape, wcs, tile_shape=None,
         idx_maps[t].shape = (1, ) + tuple(idx_maps[t].shape)
 
     # Turn the superbin index maps into thread assignments.
-    threads = pmat.assign_threads_from_map(asm_full, idx_maps)
+    threads = pmat.assign_threads_from_map(asm_full, idx_maps, n_threads=n_threads)
 
     if plot_prefix:
         pl.plot(bins, H)

--- a/python/proj/wcs.py
+++ b/python/proj/wcs.py
@@ -461,11 +461,12 @@ class Projectionist:
         if method not in THREAD_ASSIGNMENT_METHODS:
             raise ValueError(f'No thread assignment method "{method}"; '
                              f'expected one of {THREAD_ASSIGNMENT_METHODS}')
+        n_threads = mapthreads.get_num_threads(n_threads)
 
         if method == 'simple':
             projeng = self.get_ProjEng('T')
             q1 = self._get_cached_q(assembly.Q)
-            omp_ivals = projeng.pixel_ranges(q1, assembly.dets, None)
+            omp_ivals = projeng.pixel_ranges(q1, assembly.dets, None, n_threads)
             return RangesMatrix([RangesMatrix(x) for x in omp_ivals])
 
         elif method == 'domdir':
@@ -483,14 +484,13 @@ class Projectionist:
                 n_threads=n_threads, offs_rep=offs_rep)
 
         elif method == 'tiles':
-            tile_info = self.get_active_tiles(
-                assembly, assign=mapthreads.get_num_threads(n_threads))
+            tile_info = self.get_active_tiles(assembly, assign=n_threads)
             self.active_tiles = tile_info['active_tiles']
             return tile_info['group_ranges']
 
         raise RuntimeError(f"Unimplemented method: {method}.")
 
-    def assign_threads_from_map(self, assembly, tmap):
+    def assign_threads_from_map(self, assembly, tmap, n_threads=None):
         """Assign threads based on a map.
 
         The returned object can be passed to the ``threads`` argument
@@ -506,7 +506,8 @@ class Projectionist:
         """
         projeng = self.get_ProjEng('T')
         q1 = self._get_cached_q(assembly.Q)
-        omp_ivals = projeng.pixel_ranges(q1, assembly.dets, tmap)
+        n_threads = mapthreads.get_num_threads(n_threads)
+        omp_ivals = projeng.pixel_ranges(q1, assembly.dets, tmap, n_threads)
         return RangesMatrix([RangesMatrix(x) for x in omp_ivals])
 
     def get_active_tiles(self, assembly, assign=False):

--- a/src/Projection.cxx
+++ b/src/Projection.cxx
@@ -600,9 +600,11 @@ public:
         mapbufs.clear();
         for (int i_tile = 0; i_tile < bp::len(map); i_tile++) {
             if (isNone(map[i_tile])) {
+                if (populate[i_tile])
+                    throw tiling_exception(i_tile, "Projector expects tile but it is missing.");
                 mapbufs.push_back(BufferWrapper<double>());
             } else {
-                // You should be checking that presence and size matches expectation.
+                // You should be checking that the shape is as expected.
                 mapbufs.push_back(
                     BufferWrapper<double>("map", map[i_tile], false, map_shape_req));
             }
@@ -612,9 +614,9 @@ public:
     }
     double *pix(int imap, const int pixel_index[]) {
         const BufferWrapper<double> &mapbuf = mapbufs[pixel_index[0]];
-        // This assertion is needed in case the user did not populate
-        // the right set of tiles.
-        assert(mapbuf->buf != nullptr);
+        if (mapbuf->buf == nullptr)
+            throw tiling_exception(pixel_index[0],
+                                   "Attempted pointing operation on non-instantiated tile.");
         return (double*)((char*)mapbuf->buf +
                          mapbuf->strides[0]*imap +
                          mapbuf->strides[1]*pixel_index[1] +
@@ -623,9 +625,9 @@ public:
     double *wpix(int imap, int jmap, const int pixel_index[]) {
         // Expensive shared_ptr copy?
         const BufferWrapper<double> &mapbuf = mapbufs[pixel_index[0]];
-        // This assertion is needed in case the user did not populate
-        // the right set of tiles.
-        assert(mapbuf->buf != nullptr);
+        if (mapbuf->buf == nullptr)
+            throw tiling_exception(pixel_index[0],
+                                   "Attempted pointing operation on non-instantiated tile.");
         return (double*)((char*)mapbuf->buf +
                          mapbuf->strides[0]*imap +
                          mapbuf->strides[1]*jmap +

--- a/src/Projection.cxx
+++ b/src/Projection.cxx
@@ -475,6 +475,9 @@ public:
             return -1;
         return pixel_index[1] * thread_count / naxis[1];
     }
+    int tile_count() {
+        return -1;
+    }
 
     int crpix[2];
     double cdelt[2];
@@ -631,6 +634,11 @@ public:
     }
     int stripe(const int pixel_index[], int thread_count) {
         return pixel_index[0] % thread_count;
+    }
+    int tile_count() {
+        int n_ty = (parent_pix.naxis[0] + tile_shape[0] - 1) / tile_shape[0];
+        int n_tx = (parent_pix.naxis[1] + tile_shape[1] - 1) / tile_shape[1];
+        return n_tx * n_ty;
     }
 
     Pixelizor2_Flat<NonTiled> parent_pix;
@@ -959,6 +967,142 @@ bp::object ProjectionEngine<C,P,S>::pixel_ranges(
     }
 
     // Convert super vector to a list and return
+    auto ivals_out = bp::list();
+    for (int j=0; j<ranges.size(); j++) {
+        auto ivals = bp::list();
+        for (int i_det=0; i_det<n_det; i_det++) {
+            auto iv = ranges[j][i_det];
+            ivals.append(bp::object(iv));
+        }
+        ivals_out.append(bp::extract<bp::object>(ivals)());
+    }
+    return bp::extract<bp::object>(ivals_out);
+}
+
+template<typename C, typename P, typename S>
+vector<int> ProjectionEngine<C,P,S>::tile_hits(
+    bp::object pbore, bp::object pofs)
+{
+    auto _none = bp::object();
+
+    auto pointer = Pointer<C>();
+    pointer.TestInputs(_none, pbore, pofs, _none, _none);
+    int n_det = pointer.DetCount();
+    int n_time = pointer.TimeCount();
+
+    int n_tile = _pixelizor.tile_count();
+    if (n_tile < 0)
+        throw general_exception("No tiles in this pixelization.");
+
+    vector<int> hits(n_tile);
+    vector<vector<int>> temp;
+
+#pragma omp parallel
+    {
+        int n_domain = omp_get_num_threads();
+#pragma omp single
+        {
+            for (int i=0; i<n_domain; i++)
+                temp.push_back(vector<int>(n_tile));
+        }
+
+#pragma omp for
+        for (int i_det = 0; i_det < n_det; ++i_det) {
+            double dofs[4];
+            pointer.InitPerDet(i_det, dofs);
+            int pixel_offset[P::index_count] = {-1};
+            int thread = omp_get_thread_num();
+            for (int i_time = 0; i_time < n_time; ++i_time) {
+                double coords[4];
+                pointer.GetCoords(i_det, i_time, (double*)dofs, (double*)coords);
+                _pixelizor.GetPixel(i_det, i_time, (double*)coords, pixel_offset);
+                if (pixel_offset[0] >= 0)
+                    temp[thread][pixel_offset[0]]++;
+            }
+        }
+#pragma omp single
+        {
+            for (int i=0; i<n_domain; i++) {
+                for (int j=0; j<n_tile; j++)
+                    hits[j] += temp[i][j];
+            }
+        }
+    }
+
+    return hits;
+}
+
+//tile_ranges: create RangesInt32 information for n threads, such that
+//each thread is active only on certain tiles.  tile_map should be a
+//list of lists of tiles.
+template<typename C, typename P, typename S>
+bp::object ProjectionEngine<C,P,S>::tile_ranges(
+    bp::object pbore, bp::object pofs, bp::object tile_lists)
+{
+    auto _none = bp::object();
+
+    auto pointer = Pointer<C>();
+    pointer.TestInputs(_none, pbore, pofs, _none, _none);
+    int n_det = pointer.DetCount();
+    int n_time = pointer.TimeCount();
+
+    int n_tile = _pixelizor.tile_count();
+    if (n_tile < 0)
+        throw general_exception("No tiles in this pixelization.");
+
+    // Make a vector that maps tile into thread.
+    vector<int> thread_idx(n_tile, -1);
+    for (int i=0; i<bp::len(tile_lists); i++) {
+        auto tile_list = tile_lists[i];
+        for (int j=0; j<bp::len(tile_list); j++) {
+            int tile_idx = PyLong_AsLong(bp::object(tile_list[j]).ptr());
+            thread_idx[tile_idx] = i;
+       }
+    }
+
+    // Make a bunch of Ranges, index them with [thread, det].  Note
+    // thread isn't the OMP thread index, below, but the thread_index
+    // determined from tile_lists.  It's safe to populate these
+    // structures in parallel provided that only one thread touches
+    // each Ranges object, which is the case since each OMP thread
+    // below specializes in certain detectors.
+    vector<vector<RangesInt32>> ranges;
+    for (int i=0; i<bp::len(tile_lists); i++) {
+        vector<RangesInt32> v(n_det);
+        for (auto &_v: v)
+            _v.count = n_time;
+        ranges.push_back(v);
+    }
+
+#pragma omp parallel for
+    for (int i_det = 0; i_det < n_det; ++i_det) {
+        double dofs[4];
+        pointer.InitPerDet(i_det, dofs);
+        int last_slice = -1;
+        int slice_start = 0;
+        int pixel_offset[P::index_count] = {-1};
+        for (int i_time = 0; i_time < n_time; ++i_time) {
+            double coords[4];
+            pointer.GetCoords(i_det, i_time, (double*)dofs, (double*)coords);
+            _pixelizor.GetPixel(i_det, i_time, (double*)coords, pixel_offset);
+
+            int this_slice = -1;
+            if (pixel_offset[0] >= 0)
+                this_slice = thread_idx[pixel_offset[0]];
+            if (this_slice != last_slice) {
+                if (last_slice >= 0)
+                    ranges[last_slice][i_det].append_interval_no_check(
+                        slice_start, i_time);
+                slice_start = i_time;
+                last_slice = this_slice;
+            }
+        }
+        if (last_slice >= 0)
+            ranges[last_slice][i_det].append_interval_no_check(
+                slice_start, n_time);
+    }
+
+    // Convert vector<vector<Ranges>> to a list and return it.
     auto ivals_out = bp::list();
     for (int j=0; j<ranges.size(); j++) {
         auto ivals = bp::list();
@@ -1523,6 +1667,8 @@ TYPEDEF_PIX(ZEA)
     .add_property("comp_count", &CLASSNAME::comp_count)                 \
     .def("coords", &CLASSNAME::coords)                                  \
     .def("pixels", &CLASSNAME::pixels)                                  \
+    .def("tile_hits", &CLASSNAME::tile_hits)                            \
+    .def("tile_ranges", &CLASSNAME::tile_ranges)                        \
     .def("pointing_matrix", &CLASSNAME::pointing_matrix)                \
     .def("pixel_ranges", &CLASSNAME::pixel_ranges)                      \
     .def("zeros", &CLASSNAME::zeros)                                    \

--- a/src/Projection.cxx
+++ b/src/Projection.cxx
@@ -907,7 +907,7 @@ bp::object ProjectionEngine<C,P,S>::pointing_matrix(
 
 template<typename C, typename P, typename S>
 bp::object ProjectionEngine<C,P,S>::pixel_ranges(
-    bp::object pbore, bp::object pofs, bp::object map)
+    bp::object pbore, bp::object pofs, bp::object map, int n_domain)
 {
     auto _none = bp::object();
 
@@ -924,10 +924,11 @@ bp::object ProjectionEngine<C,P,S>::pixel_ranges(
 
 #pragma omp parallel
     {
-        int n_domain = omp_get_num_threads();
+        if (n_domain <= 0)
+            n_domain = omp_get_num_threads();
 #pragma omp single
         {
-            for (int i=0; i<n_domain; ++i) {
+            for (int i=0; i<n_domain; i++) {
                 vector<RangesInt32> v(n_det);
                 for (auto &_v: v)
                     _v.count = n_time;

--- a/src/exceptions.cxx
+++ b/src/exceptions.cxx
@@ -30,5 +30,6 @@ PYBINDINGS("so3g")
     bp::register_exception_translator<dtype_exception>     (&translate_ValueError);
     bp::register_exception_translator<shape_exception>     (&translate_RuntimeError);
     bp::register_exception_translator<agreement_exception> (&translate_RuntimeError);
+    bp::register_exception_translator<tiling_exception>    (&translate_RuntimeError);
     bp::register_exception_translator<general_agreement_exception> (&translate_ValueError);
 }

--- a/test/test_proj_eng.py
+++ b/test/test_proj_eng.py
@@ -86,7 +86,7 @@ class TestProjEng(unittest.TestCase):
             print(f'Assigning threads using {method}...')
             if method not in ['tiles']:
                 threads = p.assign_threads(asm, method=method, n_threads=n_threads)
-                print(threads.shape)
+                self.assertEqual(threads.shape, (n_threads,) + sig.shape)
             else:
                 with self.assertRaises(RuntimeError):
                     threads = p.assign_threads(asm, method=method, n_threads=n_threads)
@@ -101,7 +101,7 @@ class TestProjEng(unittest.TestCase):
             p = proj.Projectionist.for_tiled(shape, wcs, (150, 150), active_tiles=False)
             print(f'Assigning threads using {method}...')
             threads = p.assign_threads(asm, method=method, n_threads=n_threads)
-            print(threads.shape)
+            self.assertEqual(threads.shape, (n_threads,) + sig.shape)
 
 
 if __name__ == '__main__':

--- a/test/test_proj_eng.py
+++ b/test/test_proj_eng.py
@@ -70,8 +70,8 @@ class TestProjEng(unittest.TestCase):
             assert(np.any(w != 0))
         # Identify active subtiles?
         p = proj.Projectionist.for_tiled(shape, wcs, (20, 20))
-        print(p.pop_list)
-        p2 = p.get_active_tiles(asm)
+        print(p.active_tiles)
+        p2 = p.get_active_tiles(asm, assign=2)
         print(p2)
 
 

--- a/test/test_proj_eng.py
+++ b/test/test_proj_eng.py
@@ -11,6 +11,8 @@ try:
 except ModuleNotFoundError:
     pixell_found = False
 
+requires_pixell = unittest.skipIf(pixell_found is False, "pixell not found")
+
 DEG = np.pi/180
 
 
@@ -47,7 +49,7 @@ class TestProjEng(unittest.TestCase):
     """Test the Projectionist and supporting structures.
 
     """
-    @unittest.skipIf(pixell_found is False, "pixell not found")
+    @requires_pixell
     def test_00_basic(self):
         scan, asm, (shape, wcs) = get_basics()
         p = proj.Projectionist.for_geom(shape, wcs)
@@ -58,7 +60,7 @@ class TestProjEng(unittest.TestCase):
             w = p.to_weights(asm, comps=comps)[0, 0]
             assert(np.any(w != 0))
 
-    @unittest.skipIf(pixell_found is False, "pixell not found")
+    @requires_pixell
     def test_10_tiled(self):
         scan, asm, (shape, wcs) = get_basics()
         p = proj.Projectionist.for_tiled(shape, wcs, (150, 150))
@@ -73,6 +75,33 @@ class TestProjEng(unittest.TestCase):
         print(p.active_tiles)
         p2 = p.get_active_tiles(asm, assign=2)
         print(p2)
+
+    @requires_pixell
+    def test_20_threads(self):
+        scan, asm, (shape, wcs) = get_basics()
+        p = proj.Projectionist.for_geom(shape, wcs)
+        sig = np.ones((2, len(scan[0])), 'float32')
+        n_threads = 3
+        for method in proj.wcs.THREAD_ASSIGNMENT_METHODS:
+            print(f'Assigning threads using {method}...')
+            if method not in ['tiles']:
+                threads = p.assign_threads(asm, method=method, n_threads=n_threads)
+                print(threads.shape)
+            else:
+                with self.assertRaises(RuntimeError):
+                    threads = p.assign_threads(asm, method=method, n_threads=n_threads)
+
+    @requires_pixell
+    def test_21_threads_tiled(self):
+        scan, asm, (shape, wcs) = get_basics()
+        sig = np.ones((len(asm.dets), len(scan[0])), 'float32')
+        n_threads = 3
+        comps = 'T'
+        for method in proj.wcs.THREAD_ASSIGNMENT_METHODS:
+            p = proj.Projectionist.for_tiled(shape, wcs, (150, 150), active_tiles=False)
+            print(f'Assigning threads using {method}...')
+            threads = p.assign_threads(asm, method=method, n_threads=n_threads)
+            print(threads.shape)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This supports tile-based mapmaking.  The corresponding changes in sotodlib are [here](https://github.com/simonsobs/sotodlib/commit/609fb42a06a809995cd91716b59d161337344d29).

The major improvements are:
- C++ acceleration of tile-based stuff like "what tiles are active"
- Generalization of domdir algorithm to well with tiles

Projectionist.assign_threads has options for which algorithm to use, but defaults to 'domdir' instead of 'simple'.

The truly breaking changes should only affect tiled mapmaking.  There are some changes in internal bookkeeping for Projectionist, and the get_active_tiles function returns a dict instead of a list.