### PR TITLE
Times convert to long, not int64_t

### DIFF
--- a/src/G3SuperTimestream.cxx
+++ b/src/G3SuperTimestream.cxx
@@ -418,7 +418,7 @@ template <class A> void G3SuperTimestream::save(A &ar, unsigned v) const
 
 	if (options.times_algo == ALGO_DO_BZ) {
 		// Try to bz2 compress.  Convert to a vector of int64_t first.
-		auto time_ints = vector<int64_t>(times.begin(), times.end());
+		auto time_ints = vector<long>(times.begin(), times.end());
 		int n_samps = time_ints.size();
 		unsigned int max_bytes = n_samps * sizeof(time_ints[0]);
 


### PR DESCRIPTION
This PR fixes an error that prevented compiling `G3SuperTimestream.cxx` on MacOS+MacPorts with gcc 10.3. `G3VectorTime` can automatically cast to `long` but not `int64_t`.