### PR TITLE
Fix typo in deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.3.1
+          python -m pip install twine cibuildwheel==2.3.1
 
       - name: Build wheel
         run: |


### PR DESCRIPTION
Forgot to pip install twine after last update