### PR TITLE
G3SuperTimestream: don't crash trying to serialize 0-samples

### DIFF
--- a/src/G3SuperTimestream.cxx
+++ b/src/G3SuperTimestream.cxx
@@ -445,8 +445,9 @@ template <class A> void G3SuperTimestream::save(A &ar, unsigned v) const
 	ar & make_nvp("flac_level", options.flac_level);
 	ar & make_nvp("bz2_workFactor", options.bz2_workFactor);
 
-	if (options.times_algo == ALGO_DO_BZ) {
+	if (options.times_algo == ALGO_DO_BZ && times.size() > 0) {
 		// Try to bz2 compress.  Convert to a vector of int64_t first.
+		// Note this doesn't run unless n_samps > 0.
 		auto time_ints = vector<long>(times.begin(), times.end());
 		int n_samps = time_ints.size();
 		unsigned int max_bytes = n_samps * sizeof(time_ints[0]);

--- a/test/test_g3super.py
+++ b/test/test_g3super.py
@@ -266,7 +266,16 @@ class TestSuperTimestream(unittest.TestCase):
                 records.append(ts.data.copy())
                 f['a'] = ts
                 w.Process(f)
+
+        # show we can write a zero-sample object
+        f = core.G3Frame()
+        ts = self._get_ts(4, 0)
+        f['a0'] = ts
+        w.Process(f)
+
+        # flush
         del w
+
         # readback
         r = core.G3Reader(test_file)
         for dtype in ALL_DTYPES:


### PR DESCRIPTION
It wasn't the data, it was the vector of times...

Resolves #113 .