### PR TITLE
Only import core from spt3g when testing for existence

### DIFF
--- a/python/spt3g.py
+++ b/python/spt3g.py
@@ -10,10 +10,10 @@ try:
     sys.modules["spt3g"] = sys.modules["so3g.spt3g_internal"]
     sys.modules["spt3g"].__name__ = "spt3g"
     del sys.modules["so3g.spt3g_internal"]
-    from spt3g import core, dfmux, gcp, calibration, maps
+    from spt3g import core
 except:
     # Not bundled
     try:
-        from spt3g import core, dfmux, gcp, calibration, maps
+        from spt3g import core
     except:
         raise ImportError("Cannot import either the internal or external spt3g!")


### PR DESCRIPTION
We don't need to import anything besides `spt3g.core` when checking for its availability.  The import mechanism for both the bundled and an external spt3g will globally munge the "spt3g" modules entry to point to the correct place.  The bundled copy of spt3g includes the full package.  If / when the so3g packages internally uses something besides core, we should include that in this check.