### PR TITLE
RangesMatrix: fixes for arrays with 0-size dimension

### DIFF
--- a/python/proj/ranges.py
+++ b/python/proj/ranges.py
@@ -36,13 +36,16 @@ class RangesMatrix():
         return self.shape[0]
 
     def copy(self):
-        return RangesMatrix([x.copy() for x in self.ranges])
+        return RangesMatrix([x.copy() for x in self.ranges],
+                            child_shape=self.shape[1:])
 
     def zeros_like(self):
-        return RangesMatrix([x.zeros_like() for x in self.ranges])
+        return RangesMatrix([x.zeros_like() for x in self.ranges],
+                            child_shape=self.shape[1:])
     
     def ones_like(self):
-        return RangesMatrix([x.ones_like() for x in self.ranges])
+        return RangesMatrix([x.ones_like() for x in self.ranges],
+                            child_shape=self.shape[1:])
 
     def buffer(self, buff):
         [x.buffer(buff) for x in self.ranges]
@@ -180,9 +183,10 @@ class RangesMatrix():
                     for item in items:
                         r.extend(item.ranges() + n)
                         n += item.count
-                    r = Ranges.from_array(np.array(r, dtype='int32'), n)
+                    r = Ranges.from_array(
+                        np.array(r, dtype='int32').reshape((-1, 2)), n)
                     return r
-            return RangesMatrix(ranges)
+            return RangesMatrix(ranges, child_shape=items[0].shape[1:])
         return collect(items, axis)
 
     def get_stats(self):
@@ -231,7 +235,8 @@ class RangesMatrix():
                 r = ~r
             return r
         return RangesMatrix([RangesMatrix.full(shape[1:], fill_value)
-                             for i in range(shape[0])])
+                             for i in range(shape[0])],
+                            child_shape=shape[1:])
 
     @classmethod
     def zeros(cls, shape):

--- a/test/test_ranges.py
+++ b/test/test_ranges.py
@@ -21,6 +21,15 @@ class TestRanges(unittest.TestCase):
         self.assertCountEqual(f[0].mask(), (~t[0]).mask())
         self.assertCountEqual(f[0].mask(), (~t)[0].mask())
 
+        for shape in [(10, 100), (0, 200), (10, 0), (0, 0)]:
+            r = RangesMatrix.zeros(shape)
+            self.assertEqual(r.shape, shape)
+            r = r.copy()
+            self.assertEqual(r.shape, shape)
+            mask = np.zeros(shape=shape, dtype=bool)
+            r = RangesMatrix.from_mask(mask)
+            self.assertEqual(r.shape, shape)
+
     def test_broadcast(self):
         r0 = RangesMatrix.zeros((100, 1000))
         self.assertCountEqual(r0.shape, (100, 1000))
@@ -46,6 +55,19 @@ class TestRanges(unittest.TestCase):
 
         rc = RangesMatrix.concatenate([r0, r2], axis=0)
         self.assertCountEqual(rc.shape, (30, 100))
+
+        # Zero size is special case
+        rx = RangesMatrix.zeros((0, 100))
+        rc = RangesMatrix.concatenate([r0, rx], axis=0)
+        self.assertEqual(rc.shape, r0.shape)
+        rc = RangesMatrix.concatenate([rx, r0], axis=0)
+        self.assertEqual(rc.shape, r0.shape)
+
+        rx = RangesMatrix.zeros((10, 0))
+        rc = RangesMatrix.concatenate([r0, rx], axis=1)
+        self.assertEqual(rc.shape, r0.shape)
+        rc = RangesMatrix.concatenate([rx, r0], axis=1)
+        self.assertEqual(rc.shape, r0.shape)
 
         # These should fail due to shape incompat.
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Adds tests too.  Concatenation, copy, zeros/ones/full were all broken I think.  Whenever you use RangesMatrix(rows) constructor you have to pass child_shape!