### PR TITLE
Load ranges onepass

### DIFF
--- a/python/hk/getdata.py
+++ b/python/hk/getdata.py
@@ -737,7 +737,6 @@ def to_timestamp(some_time, str_format=None):
 
 def load_range(start, stop, fields=None, alias=None, 
                data_dir=None,config=None, pre_proc_dir=None, pre_proc_mode=None,
-               single_pass=False,
                strict=True):
     '''
     Args:
@@ -843,32 +842,15 @@ def load_range(start, stop, fields=None, alias=None,
         alias = fields
     
     # Single pass load.
-    if single_pass:
-        keepers = []
-        for name, field in zip(alias, fields):
-            if field not in all_fields:
-                hk_logger.info('`{}` not in available fields, skipping'.format(field))
-                continue
-            keepers.append((name, field))
-        data = cat.simple([f for n, f in keepers],
-                          start=start_ctime, end=stop_ctime)
-        data = {name: data[i] for i, (name, field) in enumerate(keepers)}
-    else:
-        data = {}
-        for name, field in zip(alias, fields):
-            if field not in all_fields:
-                hk_logger.info('`{}` not in available fields, skipping'.format(field))
-                continue
-            try:
-                t,x = cat.simple(field, start=start_ctime, end=stop_ctime)
-            except Exception as e:
-                if not strict and isinstance(e, KeyError):
-                    hk_logger.warning(f'{e} -- skipping field')
-                    continue
-                else:
-                    raise(e)
-            msk = np.all([t>=start_ctime, t<stop_ctime], axis=0)
-            data[name] = t[msk],x[msk]
+    keepers = []
+    for name, field in zip(alias, fields):
+        if field not in all_fields:
+            hk_logger.info('`{}` not in available fields, skipping'.format(field))
+            continue
+        keepers.append((name, field))
+    data = cat.simple([f for n, f in keepers],
+                      start=start_ctime, end=stop_ctime)
+    data = {name: data[i] for i, (name, field) in enumerate(keepers)}
 
     return data
 


### PR DESCRIPTION
(Note I'm opening _this_ PR into #132, because it's a bit more contentious.)  

@kmharrington  There are some savings to be had in load_ranges -- a single call to "simple()" will reduce the number of passes through the frame data.  The only difference in functionality here is that it doesn't catch "single field" failures.  Was there a specific failure mode you were trapping there that we could try to address some other way?

In the hk example we've been looking at, this fix increase load time by factor 2.  The improvement should scale (though not linearly, probably) with the number of fields you're trying to load.  