### PR TITLE
HKTree -- tab completion for browsing HK data

### DIFF
--- a/docs/hk.rst
+++ b/docs/hk.rst
@@ -144,6 +144,174 @@ Function References
 .. autofunction:: so3g.hk.getdata.to_timestamp
 
 
+Exploring HK Data
+-----------------
+
+The HKTree object provides a way to browse through available HK data
+fields from within an interactive python session (such as through the
+python or ipython interpreters or in a jupyter session).
+
+Instead of accessing HK fields through their long string names, such as::
+
+  field_name = "observatory.hk.rotation.feeds.hwprotation.kikusui_curr"
+
+a field can be referred to as a named object in a hierarchy of
+attributes::
+
+  tree = HKTree('2022-10-20', '2022-10-22', config='hk.yaml')
+  field = tree.hk.rotation.hwprotation.kikusui_curr
+
+By exposing the available fields as a tree of attributes, rather than
+huge set of long string keys, a user working interactively can use
+tab-completion to find fields easily.
+
+Having identified a field or set of fields of interest, the data can
+be loaded by calling pseudo-private methods on the field directly, e.g.::
+
+  data_dict = field._load()
+
+After calling load, the data are stored in the field reference itself,
+and so can be retrieved with::
+
+  times, values = field._data
+
+The ``_load`` method can be called on "non-terminal" nodes of the
+tree, for example::
+
+  data_dict = tree.hk.rotation._load()
+
+would load all the fields that are sub- (or sub-sub-, ...) attributes
+of ``tree.hk.rotation``.
+
+The system is intended to complement :func:`so3g.hk.load_range`, and
+uses the same sort of configuration file.
+
+See more detailed examples below, as well as the :ref:`Class Reference
+<HKTree Class Reference>`.
+
+Instantiating an HKTree
+```````````````````````
+
+To create an HKTree requires at least a path to an "OCS style" data
+directory (in the same sense as :func:`so3g.hk.load_range`)::
+
+  tree = hk.HKTree(data_dir='/mnt/so1/data/ucsd-sat1/hk/')
+
+By default, the returned object will only look through data from the
+past 24 hours.  To specify a range of dates of interest, use the start
+and stop parameters::
+
+  tree = hk.HKTree(data_dir='/mnt/so1/data/ucsd-sat1/hk/',
+                   start='2022-10-20', stop='2022-10-22')
+
+As with ``load_range``, passing ``data_dir`` is not necessary if the
+``OCS_DATA_DIR`` environment variable is set.  However, a config file
+may be the best way to go.
+
+
+Configuration file
+``````````````````
+
+The configuration file syntax is as in ``load_range``.  However you
+can also specify:
+
+- ``pre_proc_dir``: The default value for ``pre_proc_dir``.
+- ``skip_tokens``: Tokens to append to the ``skip`` parameter for
+  ``HKTree()``.
+
+Aliases are treated in a special way by HKTree; see `Using ._aliases`
+below.
+
+
+Finding and Loading data
+````````````````````````
+
+The nodes in the tree are all either "terminal" or not.  The terminal
+nodes are associated with a single specific HK field
+(e.g. ``tree.hk.rotation.hwprotation.kikusui_curr``) while
+non-terminal nodes are do not have associated fields, but have child
+attributes (e.g. ``tree.hk.rotation``).
+
+Data is loaded by calling ``._load()`` on any node in the tree.  This
+function will return a dictionary of data, mapping the full field names
+to tuples of data (this is similar to what ``load_range`` returns).
+
+Following load, the tuples are also available in the ``._data``
+attribute of each terminal node.  For example::
+
+  data_dict = tree.hk.rotation._load()
+
+will return a dict with multiple fields.  But after that call one can
+also access single field data on terminal nodes, e.g.::
+
+  t, val = tree.hk.rotation.kikusui_curr
+
+If you want to clear RAM / start over, call ``._clear()`` on any node
+in the tree to clear the data from all its child nodes.  E.g.::
+
+  tree.hk._clear()
+
+
+Using ._aliases
+```````````````
+
+The ``load_range`` function permits users to associate aliases with
+long field names, using the ``field_list`` in the config file (or the
+``aliases`` argument).  The ``HKTree`` makes those fields available,
+under their aliases, in a special attribute called aliases.  For
+example the config assignments like this::
+
+    field_list:
+        't40k_dr_side' : 'observatory.LEIA.feeds.temperatures.Channel_7_T'
+        't40k_far_side': 'observatory.LEIA.feeds.temperatures.Channel_8_T'
+
+would lead to the existence of attributes::
+
+  tree._aliases.t40k_dr_side
+  tree._aliases.t40k_far_side
+
+(Note that attributes can't be accessed if they begin with a digit or
+contain special characters... so avoid them in your field_list.)
+
+Fields exposed under ``._aliases`` also exist in the full tree -- the
+terminal attributes here are actually the same ones .  You
+can run ``._load()`` and ``._clear()`` on ``._aliases`` and it will
+operate on all the attributes contained there.
+
+In particular note that ``tree._aliases._load()`` should return a data
+dictionary where the alias names are used as the keys, instead of the
+
+You can dynamicaly add new fields to the aliases list (as a way of
+grouping things together under shorter names) using
+``tree._add_alias()``, providing an alias string and a target field.
+The following are equivalent::
+
+  tree._add_alias('short_name', tree.LEIA.temperatures.Channel_1_T)
+  tree._add_alias('short_name', 'observatory.tree.LEIA.feeds.temperatures.Channel_1_T')
+
+You can add a sub-tree with children; the aliases will be generated
+automatically; for example:
+
+  tree._add_alias('terms', tree.LEIA.temperatures)
+
+Would create aliases called ``'therms_Channel_1T'``,
+``'therms_Channel_2T'``, etc.
+
+
+.. _HKTree Class Reference:
+
+Class Reference
+```````````````
+
+You should see auto-generated class documentation below.
+
+.. autoclass:: so3g.hk.tree.HKTree
+   :members: _load, _clear, _add_alias
+
+.. autoclass:: so3g.hk.tree.HKRef
+   :members: _load, _clear
+
+
 Reading HK Data
 ---------------
 

--- a/python/hk/__init__.py
+++ b/python/hk/__init__.py
@@ -6,4 +6,5 @@ from .reframer import HKReframer
 from .scanner import HKScanner
 from .session import HKSessionHelper
 from .translator import HKTranslator
+from .tree import HKTree
 from . import util

--- a/python/hk/tree.py
+++ b/python/hk/tree.py
@@ -1,0 +1,309 @@
+"""HKTree: representation of an HK data archive's structure as a tree
+of attributes.
+
+"""
+
+from so3g.hk import getdata
+import time
+import os
+import yaml
+
+
+class HKRef(object):
+    """Node in an HKTree attribute tree.
+
+    Because public child attributes are generated dynamically,
+    important functionality is hidden in "private members".  The
+    ``_load`` and ``_clear`` methods are documented below, but be
+    aware also of the following attributes:
+
+    - ``_data``: The loaded data, as a tuple of arrays (t, val).
+    - ``_t``: alias for _data[0].
+    - ``_val``: alias for _data[1].
+    - ``_private``: A dict of information for managing the reference,
+      including the full field name, the root tree object, the list of
+      child refs.
+
+    """
+    _data = None
+
+    def __init__(self, name, parent, terminal):
+        super().__init__()
+        self._private = {
+            'name': name,
+            'parent': parent,
+            'children': [],
+            'terminal': terminal,
+            'alias': None,
+        }
+
+    @property
+    def _t(self):
+        if self._data:
+            return self._data[0]
+
+    @property
+    def _val(self):
+        if self.data:
+            return self._data[1]
+
+    def __getattr__(self, k):
+        # For non-private, invalid attribute names ... return an
+        # HKDeadend so user scripts don't immediately fail in cases
+        # where a field is not present during this time interval.
+        if k[0] == '_':
+            raise AttributeError(k)
+        return HKDeadend(self._private['name'] + '.' + k,
+                         self._private['parent'], False)
+
+    def __repr__(self):
+        name = self._private['name']
+        post = ' ...' if not self._private['terminal'] else ''
+        data = ' [loaded]' if self._data is not None else ''
+        return f'<{self.__class__.__name__}:{name}{post}{data}>'
+
+    def _load(self, **kw):
+        """Load the data for this node and all child nodes.  The data are
+        saved, in each terminal node, in the ``_data`` attribute as a
+        (times, values) tuple.
+
+        Returns:
+          All the data that was loaded, as a dictionary where the key
+          is the full field name and the value is the (times, values)
+          tuple.
+
+        """
+        return self._private['parent']([self], **kw)
+
+    def _clear(self):
+        """Discard any loaded data for this node and all child nodes."""
+        if self._private['terminal']:
+            self._data = None
+        else:
+            [x._clear() for x in self._private['children']]
+
+
+class HKDeadend(HKRef):
+    pass
+
+
+class HKAliasRefs(HKRef):
+    def _load(self, **kw):
+        return self._private['parent']([self], use_aliases=True, **kw)
+
+
+class HKTree:
+    def __init__(self, start=None, stop=None, config=None,
+                 data_dir=None, pre_proc_dir=None,
+                 aliases=None, skip=['observatory', 'feeds']):
+        """Scan an HK archive, between two times, and create an attribute tree
+        representing the HK data.
+
+        Args:
+
+          start (time): Earliest time to include (defaults to 1 day
+            ago).
+          stop (time): Latest time to include (defaults to 1 day after
+            start).
+          config (str): Filename of a config file (yaml).  Alternately
+            a dict can be passed in directly.
+          data_dir (str): The root directory for the HK files.
+          pre_proc_dir (str): Directory to use to store/retrieve
+            first-pass scanning data (see HKArchiveScanner).
+          aliases (dict): Map from alias name to full field name.
+            This setting does not override aliases from the config
+            file but instead will extend them.
+          skip (list of str): Tokens to suppress when turning feed
+            names (e.g. "observatory.X.feeds.Y") into tree components
+            (e.g. X.Y).
+
+        Notes:
+          Initialization of the tree requires a "first pass" scan of
+          the HK data archive.  The time range you specify is thus
+          very important in limiting the amount of IO activity.  The
+          arguments passed are closely related to the load_ranges
+          function in this module; see that docstring.
+
+          Config files that work with load_ranges should also work
+          here.
+
+        """
+        # Parse time args
+        now = time.time()
+        if start is None:
+            start = now - 86400
+        else:
+            start = getdata.to_timestamp(start)
+        if stop is None:
+            stop = start + 86400
+        else:
+            stop = getdata.to_timestamp(stop)
+
+        if aliases is None:
+            aliases = {}
+        else:
+            aliases = dict(aliases)  # copy
+
+        # Use config dict / file?
+        if isinstance(config, str):
+            config = yaml.safe_load(open(config, 'rb'))
+        if config is not None:
+            if data_dir is None:
+                data_dir = config.get('data_dir')
+            if pre_proc_dir is None:
+                pre_proc_dir = config.get('pre_proc_dir')
+
+            if config.get('field_list'):
+                for k, v in config['field_list'].items():
+                    if k not in aliases:
+                        aliases[k] = v
+            if config.get('skip_tokens'):
+                skip = skip + list(config['skip_tokens'])
+
+        # Final default substitutions.
+        if data_dir is None:
+            data_dir = os.environ['OCS_DATA_DIR']
+
+        # Walk the files -- same approach as load_ranges
+        hksc = getdata.HKArchiveScanner(pre_proc_dir=pre_proc_dir)
+        for folder in range(int(start / 1e5), int(stop / 1e5) + 1):
+            base = os.path.join(data_dir, str(folder))
+            if not os.path.exists(base):
+                continue
+
+            for filename in sorted(os.listdir(base)):
+                try:
+                    t = int(filename[:-3])
+                except ValueError:
+                    continue
+                if t >= start - 3600 and t <= stop + 3600:
+                    hksc.process_file_with_cache(os.path.join(base, filename))
+
+        self._private = {
+            'skip': skip,
+            'children': [],
+        }
+        self._private['arc'] = hksc.finalize()
+        self._private['fields'] = self._private['arc'].get_fields()
+
+        # Prepare alias reverse map...
+        rev_aliases = {v: k for k, v in aliases.items()}
+        self._aliases = HKAliasRefs('', self, False)
+
+        # Build attribute tree.
+        for k in self._private['fields'][0].keys():
+            target = self._find(k, create_missing=True)
+            if k in rev_aliases:
+                self._add_alias(rev_aliases[k], target)
+
+    def _find(self, name, create_missing=False):
+        """Find the HKRef in the attribute tree associated with a full field
+        name.  If create_missing is False, this will return None if
+        the name is not found in the tree; if create_missing is True,
+        any missing HKRef will be created and the terminal node
+        returned.
+
+        """
+        tokens = name.split('.')
+        target = self
+        name = ''
+        for i, t in enumerate(tokens):
+            end_point = (i == len(tokens) - 1)
+            name += t
+            if t not in self._private['skip']:
+                t = t.replace('-', '_')
+                if not hasattr(target, t) or \
+                   isinstance(getattr(target, t), HKDeadend):
+                    if not create_missing:
+                        return None
+                    new_node = HKRef(name, self, terminal=end_point)
+                    target._private['children'].append(new_node)
+                    setattr(target, t, new_node)
+                target = getattr(target, t)
+            name += '.'
+        return target
+
+    def _add_alias(self, alias, full_ref, _strip_prefix=None):
+        """Add a field to the set of aliases.
+
+        Args:
+          alias (str): The alias key.
+          full_ref (str or HKRef): The full name of the field or an
+            HKRef for the field.
+
+        Notes:
+
+          If the full_ref is a non-terminal HKRef, then all children will
+          be added in.  The alias for each will be constructed by
+          combining the provided alias string and the attribute names
+          of each child node, joined with '_'.
+
+        """
+        if isinstance(full_ref, str):
+            target = self._find(full_ref)
+            if target is None:
+                raise ValueError(f'No node found for "{full_ref}"')
+        else:
+            target = full_ref
+
+        # Handle non-terminal nodes
+        name = target._private['name']
+        if not target._private['terminal']:
+            if _strip_prefix is None:
+                _strip_prefix = name
+            for t in target._private['children']:
+                self._add_alias(alias, t, _strip_prefix=_strip_prefix)
+            return
+        if target._private['alias'] is not None:
+            logger.warning('Field {k} is already aliased as {k}, '
+                           'ignoring new alias.')
+            return
+        if _strip_prefix:
+            assert(name.startswith(_strip_prefix))
+            alias = alias + '_' + name[len(_strip_prefix)+1:]
+        target._private['alias'] = alias
+        clean_alias = alias.replace('.', '_').replace('-', '_')
+        setattr(self._aliases, clean_alias, target)
+        self._aliases._private['children'].append(target)
+
+    def __getattr__(self, k):
+        if k[0] == '_':
+            raise AttributeError(k)
+        return HKDeadend(k, self, False)
+
+    def _load(self, **kw):
+        """Call _load() on all child attributes and return a giant data dictionary
+        (see HKRef._load).
+
+        """
+        return self([self._children], **kw)
+
+    def _clear(self):
+        """Drop all loaded data."""
+        for c in self._private['children']:
+            c._clear()
+
+    def __call__(self, fields, use_aliases=False, **kw):
+        def get_targets(fs):
+            if isinstance(fs, HKRef):
+                if fs._private['terminal']:
+                    return [fs]
+                return get_targets(fs._private['children'])
+            fields = []
+            for f in fs:
+                fields.extend(get_targets(f))
+            return fields
+        field_targets = get_targets(fields)
+        # Tuples (field_name, key_name)
+        names = [f._private['name'] for f in field_targets]
+        if use_aliases:
+            names = [(n, n if f._private['alias'] is None
+                      else f._private['alias'])
+                     for n, f in zip(names, field_targets)]
+        else:
+            names = [(n, n) for n in names]
+        data = self._private['arc'].simple([n[0] for n in names])
+        # Populate the endpoints.
+        for t, vects in zip(field_targets, data):
+            t._data = vects
+        return {k[1]: d for k, d in zip(names, data)}


### PR DESCRIPTION
When trying to inspect some SAT data, I found I wanted a system where I could delve into the HK data hierarchy more easily, to see what was there and read in what I found.  This is an attempt to do that, using python/jupyter tab completion to assist with exploration.

I'd appreciate feedback on the interface (@kmharrington @BrianJKoopman @jlashner @jseibert575) in addition to a review (volunteers).  It is awkward to use private members (e.g. `_load`) to do things but I think it's worth it to be able to use tab completion and concise hierarchical field names.

**Preamble from the documentation:**

The HKTree object provides a way to browse through available HK data fields from within an interactive python session (such as through the python or ipython interpreters or in a jupyter session).

Instead of accessing HK fields through their long string names, such as:
```
field_name = "observatory.hk.rotation.feeds.hwprotation.kikusui_curr"
```
a field can be referred to as a named object in a hierarchy of attributes:
```
tree = HKTree('2022-10-20', '2022-10-22', config='hk.yaml')
field = tree.hk.rotation.hwprotation.kikusui_curr
```
By exposing the available fields as a tree of attributes, rather than huge set of long string keys, a user working interactively can use tab-completion to find fields easily.

Having identified a field or set of fields of interest, the data can be loaded by calling pseudo-private methods on the field directly, e.g.:
```
data_dict = field._load()
```
After calling load, the data are stored in the field reference itself, and so can be retrieved with:
```
times, values = field._data
```
The _load method can be called on “non-terminal” nodes of the tree, for example:
```
data_dict = tree.hk.rotation._load()
```
would load all the fields that are sub- (or sub-sub-, …) attributes of tree.hk.rotation.

The system is intended to complement so3g.hk.load_range, and uses the same sort of configuration file.