### PR TITLE
Changes the to_timestamp function to work with np  types

### DIFF
--- a/python/hk/getdata.py
+++ b/python/hk/getdata.py
@@ -686,7 +686,7 @@ def to_timestamp(some_time, str_format=None):
     
     if type(some_time) == dt.datetime:
         return some_time.astimezone(dt.timezone.utc).timestamp()
-    if type(some_time) == int or type(some_time) == float:
+    if isinstance(some_time, (int, float)):
         return some_time
     if type(some_time) == str:
         if str_format is not None:


### PR DESCRIPTION
Small change to the getdata module that makes the `to_timestamp` function work with numpy datatypes. If a number was of type `np.float64` checking equality of its type against float fails, but the `isinstance` function works as expected.