### PR TITLE
Suppress hk logger.info messages

### DIFF
--- a/python/hk/getdata.py
+++ b/python/hk/getdata.py
@@ -312,7 +312,7 @@ class HKArchive:
         data = {}
         timelines = {}
         for filename, file_map in sorted(files.items()):
-            hk_logger.info('get_data: reading %s' % filename)
+            hk_logger.debug('get_data: reading %s' % filename)
             reader = so3g.G3IndexedReader(filename)
             for byte_offset, frame_info in sorted(file_map.items()):
                 # Seek and decode.
@@ -877,7 +877,7 @@ def load_range(start, stop, fields=None, alias=None,
     keepers = []
     for name, field in zip(alias, fields):
         if field not in all_fields:
-            hk_logger.info('`{}` not in available fields, skipping'.format(field))
+            hk_logger.debug('`{}` not in available fields, skipping'.format(field))
             continue
         keepers.append((name, field))
     data = cat.simple([f for n, f in keepers],

--- a/python/hk/tree.py
+++ b/python/hk/tree.py
@@ -169,7 +169,7 @@ class HKTree:
             data_dir = os.environ['OCS_DATA_DIR']
 
         # Walk the files -- same approach as load_ranges
-        logger.info('Scanning %s (pre_proc=%s)' % (data_dir, pre_proc_dir))
+        logger.debug('Scanning %s (pre_proc=%s)' % (data_dir, pre_proc_dir))
         hksc = getdata.HKArchiveScanner(pre_proc_dir=pre_proc_dir)
         for folder in range(int(start / 1e5), int(stop / 1e5) + 1):
             base = os.path.join(data_dir, str(folder))


### PR DESCRIPTION
These (esp the getdata fileloop) are spamming prefect logs. Reprioritize when someone understand python logging better ...