### PR TITLE
Add ability for load_range() to read HK books

### DIFF
--- a/python/hk/getdata.py
+++ b/python/hk/getdata.py
@@ -772,7 +772,7 @@ def load_range(start, stop, fields=None, alias=None,
         files to speed up loading
       pre_proc_mode: Permissions (passed to os.chmod) to be used on
         dirs and pkl files in the pre_proc_dir. No chmod if None.
-      platform: String of type of HK book (satp1, lat, site) to load,
+      platform: String of type of HK book (Ex: satp1, lat, site) to load,
         required to open books as book directories are more specific.
       strict: If False, log and skip missing fields rather than
         raising a KeyError.
@@ -847,7 +847,7 @@ def load_range(start, stop, fields=None, alias=None,
     for folder in range( int(start_ctime/1e5), int(stop_ctime/1e5)+1):
         if platform is not None:
             book_path = 'hk_'+str(folder)+'_'+platform
-            base = '/'+data_dir+'/'+str(book_path)
+            base = data_dir+'/'+str(book_path)
         else:
             base = data_dir+'/'+str(folder)
         

--- a/python/hk/getdata.py
+++ b/python/hk/getdata.py
@@ -856,8 +856,9 @@ def load_range(start, stop, fields=None, alias=None,
                 book_path = 'hk_'+str(folder)+'_'+node
                 base = data_dir+'/'+str(book_path)
             else:
-                print(f'No daq node info provided in {data_dir}, and daq_node'
-                        'arg is None; going to assume data_dir points to .g3 files')
+                hk_logger.debug(f'No daq node info provided in {data_dir}, and'
+                                'daq_node arg is None; going to assume data_dir'
+                                'points to .g3 files')
                 # assumes .g3 files but should be more explicit
                 base = data_dir+'/'+str(folder)
         else:

--- a/python/hk/getdata.py
+++ b/python/hk/getdata.py
@@ -856,8 +856,8 @@ def load_range(start, stop, fields=None, alias=None,
                 book_path = 'hk_'+str(folder)+'_'+node
                 base = data_dir+'/'+str(book_path)
             else:
-                print(f'No daq node info provided in {data_dir}, and daq_node
-                        arg is None; going to assume data_dir is for .g3 files')
+                print(f'No daq node info provided in {data_dir}, and daq_node'
+                        'arg is None; going to assume data_dir points to .g3 files')
                 # assumes .g3 files but should be more explicit
                 base = data_dir+'/'+str(folder)
         else:

--- a/python/hk/getdata.py
+++ b/python/hk/getdata.py
@@ -755,7 +755,7 @@ def to_timestamp(some_time, str_format=None):
 
 def load_range(start, stop, fields=None, alias=None, 
                data_dir=None, config=None, pre_proc_dir=None, pre_proc_mode=None,
-               platform=None, strict=True):
+               daq_node=None, strict=True):
     """Args:
 
       start: Earliest time to search for data (see note on time
@@ -772,8 +772,9 @@ def load_range(start, stop, fields=None, alias=None,
         files to speed up loading
       pre_proc_mode: Permissions (passed to os.chmod) to be used on
         dirs and pkl files in the pre_proc_dir. No chmod if None.
-      platform: String of type of HK book (Ex: satp1, lat, site) to load,
-        required to open books as book directories are more specific.
+      daq_node:  String of type of HK book (Ex: satp1, lat, site) to load
+        if daq_node name not in data_dir. If None, daq_node name in
+        data_dir, or loading .g3 files.
       strict: If False, log and skip missing fields rather than
         raising a KeyError.
                 
@@ -850,18 +851,17 @@ def load_range(start, stop, fields=None, alias=None,
             node = i
     
     for folder in range( int(start_ctime/1e5), int(stop_ctime/1e5)+1):
-        if platform is None:
+        if daq_node is None:
             if node in data_dir:
                 book_path = 'hk_'+str(folder)+'_'+node
                 base = data_dir+'/'+str(book_path)
-                print(base)
             else:
-                print(f'No daq node information provided in {data_dir}; going to assume path' 
-                        'is for .g3 files instead of books')
+                print(f'No daq node info provided in {data_dir}, and daq_node
+                        arg is None; going to assume data_dir is for .g3 files')
                 # assumes .g3 files but should be more explicit
                 base = data_dir+'/'+str(folder)
         else:
-            book_path = 'hk_'+str(folder)+'_'+platform
+            book_path = 'hk_'+str(folder)+'_'+daq_node
             base = data_dir+'/'+str(book_path)
         
         if not os.path.exists(base):

--- a/python/hk/getdata.py
+++ b/python/hk/getdata.py
@@ -844,12 +844,25 @@ def load_range(start, stop, fields=None, alias=None,
 
     hksc = HKArchiveScanner(pre_proc_dir=pre_proc_dir)
 
+    node_options = ['satp1', 'satp2', 'satp3', 'lat', 'site']
+    for i in node_options:
+        if i in data_dir:
+            node = i
+    
     for folder in range( int(start_ctime/1e5), int(stop_ctime/1e5)+1):
-        if platform is not None:
+        if platform is None:
+            if node in data_dir:
+                book_path = 'hk_'+str(folder)+'_'+node
+                base = data_dir+'/'+str(book_path)
+                print(base)
+            else:
+                print(f'No daq node information provided in {data_dir}; going to assume path' 
+                        'is for .g3 files instead of books')
+                # assumes .g3 files but should be more explicit
+                base = data_dir+'/'+str(folder)
+        else:
             book_path = 'hk_'+str(folder)+'_'+platform
             base = data_dir+'/'+str(book_path)
-        else:
-            base = data_dir+'/'+str(folder)
         
         if not os.path.exists(base):
             hk_logger.debug('{} does not exist, skipping'.format(base))


### PR DESCRIPTION
`load_range()` assumes the path structure is `/hk/<timecode>` but the books are
`hk/hk_16902_satp3`,  `hk_16903_satp3`, for example.  

I added an argument to `load_range()` called `platform` which you define as `'satp2'`, `'lat'`, `'site'`, etc. This triggers `load_range()` to know we're dealing with the books path structure.

Has been tested on HK books at the site.