### PR TITLE
Cuts resampling support (used by multiplass mapmaking)

### DIFF
--- a/python/proj/wcs.py
+++ b/python/proj/wcs.py
@@ -592,7 +592,6 @@ class Projectionist:
         q_native = self._cache_q_fp_to_native(assembly.Q)
         # This returns a G3VectorInt of length n_tiles giving count of hits per tile.
         hits = np.array(projeng.tile_hits(q_native, assembly.dets))
-        print("hits", hits)
         tiles = np.nonzero(hits)[0]
         hits = hits[tiles]
         if assign is True:


### PR DESCRIPTION
This pull request adds support for resampling cuts to a new sample rate. This is needed in the multipass mapmaking support, where we want to be able to change the sample rate between different passes.

It also cleans up an unnecessary `ndet` argument in the internal cuts implementation details, which doesn't change the interface.

Finally, it replaces some tabs with whitespace in the same file.