### PR TITLE
Fix ranges tests

### DIFF
--- a/python/proj/ranges.py
+++ b/python/proj/ranges.py
@@ -67,7 +67,7 @@ class RangesMatrix():
     def __getitem__(self, index):
         if index is None:
             index = (None,)
-        if isinstance(index, slice):
+        if isinstance(index, (slice, np.ndarray)):
             index = (index,)
         if isinstance(index, tuple) and len(index) == 0:
             return self
@@ -95,7 +95,7 @@ class RangesMatrix():
                 raise IndexError("Too many indices to RangesMatrix.")
 
             if isinstance(index[0], np.ndarray):
-                if index[0].dtype is bool:
+                if index[0].dtype == bool:
                     return RangesMatrix([self.ranges[i][index[1:]]
                                            for i in index[0].nonzero()[0]])
                 return RangesMatrix([self.ranges[i][index[1:]] for i in index[0]],

--- a/test/test_ranges.py
+++ b/test/test_ranges.py
@@ -11,15 +11,15 @@ class TestRanges(unittest.TestCase):
     def test_ranges(self):
         mask = np.array([True, True, False, True, False, True])
         r = Ranges.from_mask(mask)
-        self.assertCountEqual(r.ranges().shape, (3,2))
-        self.assertCountEqual(r.mask(), mask)
+        self.assertEqual(r.ranges().shape, (3,2))
+        np.testing.assert_equal(r.mask(), mask)
 
     def test_matrix(self):
         f = RangesMatrix.zeros((100,100))
         t = RangesMatrix.ones((100,100))
-        self.assertCountEqual(f[0].mask(), ~(t[0].mask()))
-        self.assertCountEqual(f[0].mask(), (~t[0]).mask())
-        self.assertCountEqual(f[0].mask(), (~t)[0].mask())
+        np.testing.assert_equal(f[0].mask(), ~(t[0].mask()))
+        np.testing.assert_equal(f[0].mask(), (~t[0]).mask())
+        np.testing.assert_equal(f[0].mask(), (~t)[0].mask())
 
         for shape in [(10, 100), (0, 200), (10, 0), (0, 0)]:
             r = RangesMatrix.zeros(shape)
@@ -47,9 +47,9 @@ class TestRanges(unittest.TestCase):
 
     def test_broadcast(self):
         r0 = RangesMatrix.zeros((100, 1000))
-        self.assertCountEqual(r0.shape, (100, 1000))
-        self.assertCountEqual(r0[None,:,:].shape, (1, 100, 1000))
-        self.assertCountEqual(r0[:,None,:].shape, (100, 1, 1000))
+        self.assertEqual(r0.shape, (100, 1000))
+        self.assertEqual(r0[None,:,:].shape, (1, 100, 1000))
+        self.assertEqual(r0[:,None,:].shape, (100, 1, 1000))
 
         # It should not be possible to pad or index beyond the
         # outermost dimension.  Ranges isn't very smart about this,
@@ -65,11 +65,11 @@ class TestRanges(unittest.TestCase):
         r2 = RangesMatrix.ones ((20, 100))
 
         rc = RangesMatrix.concatenate([r0, r1], axis=1)
-        self.assertCountEqual(rc.shape, (10, 300))
+        self.assertEqual(rc.shape, (10, 300))
         self.assertEqual(rc[0].mask().sum(), r1[0].mask().sum())
 
         rc = RangesMatrix.concatenate([r0, r2], axis=0)
-        self.assertCountEqual(rc.shape, (30, 100))
+        self.assertEqual(rc.shape, (30, 100))
 
         # Zero size is special case
         rx = RangesMatrix.zeros((0, 100))

--- a/test/test_ranges.py
+++ b/test/test_ranges.py
@@ -30,6 +30,21 @@ class TestRanges(unittest.TestCase):
             r = RangesMatrix.from_mask(mask)
             self.assertEqual(r.shape, shape)
 
+    def test_indexing(self):
+        r = RangesMatrix.zeros((100, 10000))
+        for i in range(len(r)):
+            r[i].add_interval(i, i+1000)
+        i = np.array([1, 3, 10])
+        r1 = r[i]
+        for _r, _i in zip(r1, i):
+            self.assertEqual(_r.ranges()[0][0], _i)
+
+        s = np.zeros(len(r), bool)
+        s[i] = True
+        r2 = r[s]
+        for _r, _i in zip(r2, i):
+            self.assertEqual(_r.ranges()[0][0], _i)
+
     def test_broadcast(self):
         r0 = RangesMatrix.zeros((100, 1000))
         self.assertCountEqual(r0.shape, (100, 1000))


### PR DESCRIPTION
This started as a bug fix to RangesMatrix (dtype == bool rather than dtype is bool), but ended up with:
- that bugfix
- now accepts a single numpy array as an index [] (doesn't have to be wrapped in a tuple)
- tests are improved to cover the bugfix, and indexing with arrays
- erroneous use of assertCountEqual replaced with numpy.testing.assert*