### PR TITLE
Optimization of the proj for the case of some of det_weights == 0.0

### DIFF
--- a/src/Projection.cxx
+++ b/src/Projection.cxx
@@ -1390,6 +1390,7 @@ void to_map_single_thread(Pointer<C> &pointer,
         if (_det_weights->obj != NULL)
             det_wt = *(FSIGNAL*)((char*)_det_weights->buf +
                                  _det_weights->strides[0]*i_det);
+            if (det_wt == 0.) continue;
         double dofs[4];
         double coords[4];
         FSIGNAL pf[S::comp_count];
@@ -1426,6 +1427,7 @@ void to_weight_map_single_thread(Pointer<C> &pointer,
         if (_det_weights->obj != NULL)
             det_wt = *(FSIGNAL*)((char*)_det_weights->buf +
                                  _det_weights->strides[0]*i_det);
+            if (det_wt == 0.) continue;
         double dofs[4];
         double coords[4];
         FSIGNAL pf[S::comp_count];
@@ -1696,6 +1698,7 @@ void precomp_to_map_single_thread(Pixelizor2_Flat<TilingSys> &tiling,
         FSIGNAL det_wt = 1.;
         if (_det_weights->obj != NULL)
             det_wt = *(FSIGNAL*)((char*)_det_weights->buf + _det_weights->strides[0]*i_det);
+            if (det_wt == 0.) continue;
 
         for (auto const &rng: ivals[i_det].segments) {
             for (int i_time = rng.first; i_time < rng.second; ++i_time) {
@@ -1730,6 +1733,7 @@ void precomp_to_weight_map_single_thread(Pixelizor2_Flat<TilingSys> &tiling,
         FSIGNAL det_wt = 1.;
         if (_det_weights->obj != NULL)
             det_wt = *(FSIGNAL*)((char*)_det_weights->buf + _det_weights->strides[0]*i_det);
+            if (det_wt == 0.) continue;
 
         for (auto const &rng: ivals[i_det].segments) {
             for (int i_time = rng.first; i_time < rng.second; ++i_time) {

--- a/src/Projection.cxx
+++ b/src/Projection.cxx
@@ -1387,10 +1387,11 @@ void to_map_single_thread(Pointer<C> &pointer,
     int n_det = pointer.DetCount();
     for (int i_det = 0; i_det < n_det; ++i_det) {
         FSIGNAL det_wt = 1.;
-        if (_det_weights->obj != NULL)
+        if (_det_weights->obj != NULL){
             det_wt = *(FSIGNAL*)((char*)_det_weights->buf +
                                  _det_weights->strides[0]*i_det);
             if (det_wt == 0.) continue;
+        }
         double dofs[4];
         double coords[4];
         FSIGNAL pf[S::comp_count];
@@ -1424,10 +1425,11 @@ void to_weight_map_single_thread(Pointer<C> &pointer,
     int n_det = pointer.DetCount();
     for (int i_det = 0; i_det < n_det; ++i_det) {
         FSIGNAL det_wt = 1.;
-        if (_det_weights->obj != NULL)
+        if (_det_weights->obj != NULL){
             det_wt = *(FSIGNAL*)((char*)_det_weights->buf +
                                  _det_weights->strides[0]*i_det);
             if (det_wt == 0.) continue;
+        }
         double dofs[4];
         double coords[4];
         FSIGNAL pf[S::comp_count];
@@ -1696,10 +1698,10 @@ void precomp_to_map_single_thread(Pixelizor2_Flat<TilingSys> &tiling,
 
     for (int i_det = 0; i_det < n_det; ++i_det) {
         FSIGNAL det_wt = 1.;
-        if (_det_weights->obj != NULL)
+        if (_det_weights->obj != NULL){
             det_wt = *(FSIGNAL*)((char*)_det_weights->buf + _det_weights->strides[0]*i_det);
             if (det_wt == 0.) continue;
-
+        }
         for (auto const &rng: ivals[i_det].segments) {
             for (int i_time = rng.first; i_time < rng.second; ++i_time) {
                 const int *pixel_offset = pixel_buf_man.data_ptr[i_det] +
@@ -1731,10 +1733,10 @@ void precomp_to_weight_map_single_thread(Pixelizor2_Flat<TilingSys> &tiling,
     assert(spin_proj_man.steps[1] == 1); // assumed below
     for (int i_det = 0; i_det < n_det; ++i_det) {
         FSIGNAL det_wt = 1.;
-        if (_det_weights->obj != NULL)
+        if (_det_weights->obj != NULL){
             det_wt = *(FSIGNAL*)((char*)_det_weights->buf + _det_weights->strides[0]*i_det);
             if (det_wt == 0.) continue;
-
+        }
         for (auto const &rng: ivals[i_det].segments) {
             for (int i_time = rng.first; i_time < rng.second; ++i_time) {
                 const int *pixel_offset = pixel_buf_man.data_ptr[i_det] +


### PR DESCRIPTION
This PR makes the map making faster in the case of some of det_weights == 0.
Applications are making single_det_maps for all detector or managing null splits.
For the detail, follow conversation in issue #147 .