### PR TITLE
proj: avoid segfaults due to NaN pointing offsets

### DIFF
--- a/include/exceptions.h
+++ b/include/exceptions.h
@@ -9,14 +9,37 @@
 class so3g_exception : std::exception
 {
 public:
-    virtual std::string msg_for_python() const throw() = 0;
+    std::string text;
+    so3g_exception() {};
+
+    so3g_exception(std::string text) :
+        text{text} {}
+
+    std::string msg_for_python() const throw() {
+        return text;
+    }
+};
+
+
+// The base classes here are mapped to specific Python exceptions.
+// They are registered with boost python in exceptions.cxx.  Sure, you
+// can use these directly.  Why not.
+
+class RuntimeError_exception : public so3g_exception {
+    using so3g_exception::so3g_exception;
+};
+class TypeError_exception : public so3g_exception {
+    using so3g_exception::so3g_exception;
+};
+class ValueError_exception : public so3g_exception {
+    using so3g_exception::so3g_exception;
 };
 
 
 // The exceptions below should be used when processing objects with
 // the buffer protocol (probably numpy arrays).
 
-class buffer_exception : public so3g_exception
+class buffer_exception : public TypeError_exception
 {
 public:
     std::string var_name;
@@ -30,7 +53,7 @@ public:
     }
 };
 
-class shape_exception : public so3g_exception
+class shape_exception : public RuntimeError_exception
 {
 public:
     std::string var_name;
@@ -46,7 +69,7 @@ public:
     }
 };
 
-class dtype_exception : public so3g_exception
+class dtype_exception : public ValueError_exception
 {
 public:
     std::string var_name;
@@ -62,7 +85,7 @@ public:
     }
 };
 
-class agreement_exception : public so3g_exception
+class agreement_exception : public RuntimeError_exception
 {
 public:
     std::string var1, var2, prop;
@@ -77,7 +100,7 @@ public:
     }
 };
 
-class tiling_exception : public so3g_exception
+class tiling_exception : public RuntimeError_exception
 {
 public:
     int tile_idx;
@@ -92,23 +115,11 @@ public:
     }
 };
 
-class general_agreement_exception : public so3g_exception
+class general_agreement_exception : public ValueError_exception
 {
 public:
     std::string text;
     general_agreement_exception(std::string text) :
-        text{text} {}
-
-    std::string msg_for_python() const throw() {
-        return text;
-    }
-};
-
-class general_exception : public so3g_exception
-{
-public:
-    std::string text;
-    general_exception(std::string text) :
         text{text} {}
 
     std::string msg_for_python() const throw() {

--- a/include/numpy_assist.h
+++ b/include/numpy_assist.h
@@ -157,11 +157,11 @@ public:
     // Constructor with no shape or type checking.
     BufferWrapper(std::string name, const bp::object &src, bool optional)
         : BufferWrapper() {
+        if (optional && (src.ptr() == Py_None))
+            return;
         if (PyObject_GetBuffer(src.ptr(), view.get(),
                                PyBUF_RECORDS) == -1) {
             PyErr_Clear();
-            if (optional)
-                return;
             throw buffer_exception(name);
         }
     }

--- a/src/Projection.cxx
+++ b/src/Projection.cxx
@@ -180,6 +180,20 @@ bool Pointer<CoordSys>::TestInputs(
                                      vector<int>{-1, 4});
     n_time = _pborebuf->shape[0];
     n_det = _pdetbuf->shape[0];
+
+    // Check the detectors for NaNs.
+    for (int i=0; i<n_det; i++) {
+        for (int ic = 0; ic < 4; ++ic) {
+            const char *x = (char*)_pdetbuf->buf
+                + _pdetbuf->strides[0] * i
+                + _pdetbuf->strides[1] * ic;
+            if (std::isnan(*(double*)x)) {
+                std::ostringstream err;
+                err << "Pointing offset error: nan found at index " << i << ".";
+                throw ValueError_exception(err.str());
+            }
+        }
+    }
     return true;
 }
 

--- a/src/Projection.cxx
+++ b/src/Projection.cxx
@@ -1163,7 +1163,7 @@ vector<int> ProjectionEngine<C,P,S>::tile_hits(
 
     int n_tile = _pixelizor.tile_count();
     if (n_tile < 0)
-        throw general_exception("No tiles in this pixelization.");
+        throw RuntimeError_exception("No tiles in this pixelization.");
 
     vector<int> hits(n_tile);
     vector<vector<int>> temp;
@@ -1226,7 +1226,7 @@ bp::object ProjectionEngine<C,P,S>::tile_ranges(
 
     int n_tile = _pixelizor.tile_count();
     if (n_tile < 0)
-        throw general_exception("No tiles in this pixelization.");
+        throw RuntimeError_exception("No tiles in this pixelization.");
     int n_domain = bp::len(tile_lists);
 
     // Make a vector that maps tile into thread.

--- a/src/array_ops.cxx
+++ b/src/array_ops.cxx
@@ -124,7 +124,7 @@ int process_cuts(const bp::object & range_matrix, const std::string & operation,
     else if(model == "poly") {
         resolution = bp::extract<int>(params.get("resolution"));
         nmax       = bp::extract<int>(params.get("nmax"));
-    } else throw general_exception("process_cuts model can only be 'full' or 'poly'");
+    } else throw ValueError_exception("process_cuts model can only be 'full' or 'poly'");
 
     if(operation == "measure") {
         if     (model == "full") return pcut_full_measure_helper(ranges);
@@ -147,7 +147,7 @@ int process_cuts(const bp::object & range_matrix, const std::string & operation,
                     pcut_poly_tod2vals_helper(ranges, resolution, nmax, (float*)tod_buf->buf, nsamp, (float*) vals_buf->buf);
             } else if(operation == "clear") {
                 pcut_clear_helper(ranges, (float*)tod_buf->buf, nsamp);
-            } else throw general_exception("process_cuts operation can only be 'measure', 'insert' or 'extract'");
+            } else throw ValueError_exception("process_cuts operation can only be 'measure', 'insert' or 'extract'");
         } else if(dtype == NPY_DOUBLE) {
             BufferWrapper<double> tod_buf  ("tod",  tod,  false, std::vector<int>{-1,-1});
             BufferWrapper<double> vals_buf ("vals", vals, false, std::vector<int>{-1});
@@ -164,8 +164,8 @@ int process_cuts(const bp::object & range_matrix, const std::string & operation,
                     pcut_poly_tod2vals_helper(ranges, resolution, nmax, (double*)tod_buf->buf, nsamp, (double*) vals_buf->buf);
             } else if(operation == "clear") {
                 pcut_clear_helper(ranges, (float*)tod_buf->buf, nsamp);
-            } else throw general_exception("process_cuts operation can only be 'measure', 'insert' or 'extract'");
-        } else throw general_exception("process_cuts only supports float32 and float64");
+            } else throw ValueError_exception("process_cuts operation can only be 'measure', 'insert' or 'extract'");
+        } else throw TypeError_exception("process_cuts only supports float32 and float64");
     }
     return 0;
 }
@@ -179,7 +179,7 @@ void translate_cuts(const bp::object & irange_matrix, const bp::object & orange_
         resolution = bp::extract<int>(params.get("resolution"));
         nmax       = bp::extract<int>(params.get("nmax"));
     } else {
-        throw general_exception("process_cuts model can only be 'full' or 'poly'");
+        throw ValueError_exception("process_cuts model can only be 'full' or 'poly'");
     }
     auto iranges = extract_ranges<int32_t>(irange_matrix);
     auto oranges = extract_ranges<int32_t>(orange_matrix);

--- a/src/exceptions.cxx
+++ b/src/exceptions.cxx
@@ -26,10 +26,13 @@ static void translate_ValueError(so3g_exception const& e)
 namespace bp = boost::python;
 PYBINDINGS("so3g")
 {
-    bp::register_exception_translator<buffer_exception>    (&translate_TypeError);
-    bp::register_exception_translator<dtype_exception>     (&translate_ValueError);
-    bp::register_exception_translator<shape_exception>     (&translate_RuntimeError);
-    bp::register_exception_translator<agreement_exception> (&translate_RuntimeError);
-    bp::register_exception_translator<tiling_exception>    (&translate_RuntimeError);
-    bp::register_exception_translator<general_agreement_exception> (&translate_ValueError);
+    // bp::register_exception_translator<buffer_exception>    (&translate_TypeError);
+    // bp::register_exception_translator<dtype_exception>     (&translate_ValueError);
+    // bp::register_exception_translator<shape_exception>     (&translate_RuntimeError);
+    // bp::register_exception_translator<agreement_exception> (&translate_RuntimeError);
+    // bp::register_exception_translator<tiling_exception>    (&translate_RuntimeError);
+    // bp::register_exception_translator<general_agreement_exception> (&translate_ValueError);
+    bp::register_exception_translator<RuntimeError_exception> (&translate_RuntimeError);
+    bp::register_exception_translator<TypeError_exception> (&translate_TypeError);
+    bp::register_exception_translator<ValueError_exception> (&translate_ValueError);
 }

--- a/test/test_proj_eng.py
+++ b/test/test_proj_eng.py
@@ -64,6 +64,18 @@ class TestProjEng(unittest.TestCase):
             w = p.to_weights(asm, comps=comps)[0, 0]
             assert(np.any(w != 0))
 
+        # Does det_weights seem to work?
+        m = p.to_map(sig, asm, comps='T',
+                     det_weights=np.array([0., 0.], dtype='float32'))[0]
+        assert(np.all(m==0))
+
+        # Raise if pointing invalid.
+        asm.dets[1,2] = np.nan
+        with self.assertRaises(ValueError):
+           p.to_map(sig, asm, comps='T')
+        with self.assertRaises(ValueError):
+           p.to_weights(asm, comps='T')
+
     @requires_pixell
     def test_10_tiled(self):
         scan, asm, (shape, wcs) = get_basics()


### PR DESCRIPTION
This is also being mitigated in sotodlib, but ideally there would be no segfault possible due to malformed inputs, at the official interface.

The current treatment will raise an exception if there are NaNs in the offsets.  This isn't the only way, nor the best way.  One could imagine only requiring non-Nan when det_weight != 0.  But _that_ sort of thing can be smoothed over in sotodlib pretty easily.