### PR TITLE
G3SuperTimestream.extract(...)

### DIFF
--- a/docs/cpp_objects.rst
+++ b/docs/cpp_objects.rst
@@ -103,6 +103,37 @@ debugging and should not be messed with lightly.
 .. _`FLAC__stream_encoder_set_compression_level`: https://xiph.org/flac/api/group__flac__stream__encoder.html#gae49cf32f5256cb47eecd33779493ac85
 .. _`BZ2_bzCompressInit`: https://www.sourceware.org/bzip2/manual/manual.html#bzcompress-init
 
+Controlling Decompression
+`````````````````````````
+
+A G3SuperTimestream, whether constructed in situ or recovered from a
+G3Frame, will automatically decompress itself if you ask for the
+``.data`` array::
+
+  # .data will be created if it is referenced.
+  print(ts.data)
+
+  # Or you can trigger decompression manually (which will populate
+  # ts.data).
+  ts.Decode()
+
+
+If the compressed data is not yet decoded (the user has not accessed
+``.data``, nor called ``.decode()``) then a subset of the channels may
+be extracted directly into an output array, using ``.extract(dest,
+indices)``::
+
+  # Extract full data without "decompressing" ts.
+  shape = (len(ts.names), len(ts.times))
+  dest = np.empty(shape, dtype=ts.dtype)
+  ts.extract(dest, None)
+
+  # Extract only data for detector at index 1.
+  indices = np.array([1])
+  dest = np.empty((len(indices), len(ts.times)), dtype=ts.dtype)
+  ts.extract(dest, indices)
+
+
 How to work with float arrays
 `````````````````````````````
 

--- a/docs/cpp_objects.rst
+++ b/docs/cpp_objects.rst
@@ -126,12 +126,17 @@ indices)``::
   # Extract full data without "decompressing" ts.
   shape = (len(ts.names), len(ts.times))
   dest = np.empty(shape, dtype=ts.dtype)
-  ts.extract(dest, None)
+  ts.extract(dest, None, None)
 
   # Extract only data for detector at index 1.
   indices = np.array([1])
   dest = np.empty((len(indices), len(ts.times)), dtype=ts.dtype)
-  ts.extract(dest, indices)
+  ts.extract(dest, None, indices)
+
+  # Map data at [1, 3, 5] into output at [0, 2, 4].
+  dest = np.empty((6, len(ts.times)), dtype=ts.dtype)
+  ts.extract(dest, np.array([0, 2, 4]), np.array([1, 3, 5]))
+
 
 
 How to work with float arrays

--- a/docs/cpp_objects.rst
+++ b/docs/cpp_objects.rst
@@ -126,7 +126,7 @@ indices)``::
   # Extract full data without "decompressing" ts.
   shape = (len(ts.names), len(ts.times))
   dest = np.empty(shape, dtype=ts.dtype)
-  ts.extract(dest, None, None)
+  ts.extract(dest)
 
   # Extract only data for detector at index 1.
   indices = np.array([1])
@@ -136,6 +136,10 @@ indices)``::
   # Map data at [1, 3, 5] into output at [0, 2, 4].
   dest = np.empty((6, len(ts.times)), dtype=ts.dtype)
   ts.extract(dest, np.array([0, 2, 4]), np.array([1, 3, 5]))
+
+  # Extract all dets, samples [100:200].
+  dest = np.empty((len(ts.names), 100), dtype=ts.dtype)
+  ts.extract(dest, None, None, 100, 200)
 
 
 

--- a/include/G3SuperTimestream.h
+++ b/include/G3SuperTimestream.h
@@ -39,7 +39,7 @@ public:
 	string Description() const;
 	string Summary() const;
 
-	bool Extract(bp::object dest, bp::object indices);
+	bool Extract(bp::object dest, bp::object dest_indices, bp::object src_indices);
 	bool Encode();
 	bool Decode();
 	void Calibrate(vector<double> rescale);

--- a/include/G3SuperTimestream.h
+++ b/include/G3SuperTimestream.h
@@ -39,7 +39,7 @@ public:
 	string Description() const;
 	string Summary() const;
 
-	bool Extract(bp::object dest);
+	bool Extract(bp::object dest, bp::object indices);
 	bool Encode();
 	bool Decode();
 	void Calibrate(vector<double> rescale);

--- a/include/G3SuperTimestream.h
+++ b/include/G3SuperTimestream.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "so3g_numpy.h"
+#include "numpy_assist.h"
 #include <G3Frame.h>
 #include <G3Map.h>
 

--- a/include/G3SuperTimestream.h
+++ b/include/G3SuperTimestream.h
@@ -40,7 +40,8 @@ public:
 	string Description() const;
 	string Summary() const;
 
-	bool Extract(bp::object dest, bp::object dest_indices, bp::object src_indices);
+	bool Extract(bp::object dest, bp::object dest_indices, bp::object src_indices,
+		     int start, int stop);
 	bool Encode();
 	bool Decode();
 	void Calibrate(vector<double> rescale);

--- a/include/G3SuperTimestream.h
+++ b/include/G3SuperTimestream.h
@@ -39,6 +39,7 @@ public:
 	string Description() const;
 	string Summary() const;
 
+	bool Extract(bp::object dest);
 	bool Encode();
 	bool Decode();
 	void Calibrate(vector<double> rescale);

--- a/include/numpy_assist.h
+++ b/include/numpy_assist.h
@@ -211,6 +211,23 @@ public:
         }
     }
 
+    // These accessors are for convenience but you should probably
+    // roll your own for inner loops.
+    inline
+    T* ptr_1d(int i0) {
+        return (T*)((char*)view->buf + view->strides[0] * i0);
+    }
+
+    inline
+    T* ptr_2d(int i0, int i1) {
+        return (T*)((char*)view->buf + view->strides[0] * i0 + view->strides[1] * i1);
+    }
+
+    inline
+    bool test() {
+        return view->obj != nullptr;
+    }
+
 private:
     std::shared_ptr<Py_buffer> view;
 };

--- a/test/test_g3super.py
+++ b/test/test_g3super.py
@@ -334,6 +334,53 @@ class TestSuperTimestream(unittest.TestCase):
             # I think the theoretical limit is 1.3 or so...
             self.assertLess(bits_per_word, sigma_bits * 1.4, err_msg)
 
+    def test_60_extract(self):
+        """Test selective extraction."""
+        def _get_ts():
+            ts = self._get_ts(5, 100, seed=100, dtype='float32')
+            ts.encode()
+            return ts
+
+        ts = _get_ts()
+        dest = np.zeros((5, 100), dtype='float32')
+        ts.extract(dest, None)
+        np.testing.assert_array_equal(dest, ts.data)
+
+        for dest in [
+                np.zeros((4, 100), dtype='float32'),
+                np.zeros((100), dtype='float32'),
+                np.zeros((5, 100), dtype='int32'),
+                ['blech'],
+                ]:
+            ts = _get_ts()
+            with self.assertRaises(ValueError):
+                ts.extract(dest, None)
+
+        ts = _get_ts()
+        idx = np.array([2, 1, 3])
+        dest = np.zeros((len(idx), 100), dtype='float32')
+        ts.extract(dest, idx)
+        np.testing.assert_array_equal(dest, ts.data[idx])
+
+        ts = _get_ts()
+        dest = np.zeros((4, 100), dtype='float32')
+        with self.assertRaises(ValueError):
+            ts.extract(dest, idx)
+
+        dest = np.zeros((len(idx), 200), dtype='float32')[:,::2]
+        with self.assertRaises(ValueError):
+            ts.extract(dest, idx)
+
+        # What if decoded already?  This should fail (but not
+        # segfault) -- subject to change.
+        ts = _get_ts()
+        ts.decode()
+        idx = np.array([2, 1, 3])
+        dest = np.zeros((len(idx), 100), dtype='float32')
+        with self.assertRaises(ValueError):
+            ts.extract(dest, idx)
+
+
     # Support functions
 
     def _get_ts(self, nchans, ntimes, sigma=256, dtype='int32', raw=False, seed=None):

--- a/test/test_g3super.py
+++ b/test/test_g3super.py
@@ -356,10 +356,13 @@ class TestSuperTimestream(unittest.TestCase):
             with self.assertRaises(ValueError):
                 ts.extract(dest)
 
-        ts = _get_ts()
         idx = np.array([2, 1, 3])
         dest = np.zeros((len(idx), 100), dtype='float32')
+        ts = _get_ts()
         ts.extract(dest, None, idx)
+        np.testing.assert_array_equal(dest, ts.data[idx])
+        ts = _get_ts()
+        ts.extract(dest, src_indices=idx)
         np.testing.assert_array_equal(dest, ts.data[idx])
 
         ts = _get_ts()
@@ -379,6 +382,11 @@ class TestSuperTimestream(unittest.TestCase):
         dest = np.zeros((len(idx), 100), dtype='float32')
         with self.assertRaises(ValueError):
             ts.extract(dest, None, idx)
+
+        # Sample subset
+        ts = _get_ts()
+        dest = np.zeros((5, 91-10), dtype='float32')
+        ts.extract(dest, start=10, stop=91)
 
         #Injection test.
         ts = _get_ts()

--- a/test/test_g3super.py
+++ b/test/test_g3super.py
@@ -343,7 +343,7 @@ class TestSuperTimestream(unittest.TestCase):
 
         ts = _get_ts()
         dest = np.zeros((5, 100), dtype='float32')
-        ts.extract(dest, None, None)
+        ts.extract(dest)
         np.testing.assert_array_equal(dest, ts.data)
 
         for dest in [
@@ -354,7 +354,7 @@ class TestSuperTimestream(unittest.TestCase):
                 ]:
             ts = _get_ts()
             with self.assertRaises(ValueError):
-                ts.extract(dest, None, None)
+                ts.extract(dest)
 
         ts = _get_ts()
         idx = np.array([2, 1, 3])
@@ -384,9 +384,9 @@ class TestSuperTimestream(unittest.TestCase):
         ts = _get_ts()
         src_i = np.array([2, 1, 3])
         dest_i = np.array([0, 4, 2])
-        dest = np.zeros((5, 100), dtype='float32')
-        ts.extract(dest, dest_i, src_i)
-        np.testing.assert_array_equal(dest[dest_i], ts.data[src_i])
+        dest = np.zeros((5, 91-10), dtype='float32')
+        ts.extract(dest, dest_i, src_i, 10, 91)
+        np.testing.assert_array_equal(dest[dest_i], ts.data[src_i,10:91])
         self.assertEqual(True, np.all(dest[[1, 3]] == 0))
 
     # Support functions

--- a/test/test_g3super.py
+++ b/test/test_g3super.py
@@ -343,7 +343,7 @@ class TestSuperTimestream(unittest.TestCase):
 
         ts = _get_ts()
         dest = np.zeros((5, 100), dtype='float32')
-        ts.extract(dest, None)
+        ts.extract(dest, None, None)
         np.testing.assert_array_equal(dest, ts.data)
 
         for dest in [
@@ -354,22 +354,22 @@ class TestSuperTimestream(unittest.TestCase):
                 ]:
             ts = _get_ts()
             with self.assertRaises(ValueError):
-                ts.extract(dest, None)
+                ts.extract(dest, None, None)
 
         ts = _get_ts()
         idx = np.array([2, 1, 3])
         dest = np.zeros((len(idx), 100), dtype='float32')
-        ts.extract(dest, idx)
+        ts.extract(dest, None, idx)
         np.testing.assert_array_equal(dest, ts.data[idx])
 
         ts = _get_ts()
-        dest = np.zeros((4, 100), dtype='float32')
+        dest = np.zeros((1, 2, 100), dtype='float32')
         with self.assertRaises(ValueError):
-            ts.extract(dest, idx)
+            ts.extract(dest, None, idx)
 
         dest = np.zeros((len(idx), 200), dtype='float32')[:,::2]
         with self.assertRaises(ValueError):
-            ts.extract(dest, idx)
+            ts.extract(dest, None, idx)
 
         # What if decoded already?  This should fail (but not
         # segfault) -- subject to change.
@@ -378,8 +378,16 @@ class TestSuperTimestream(unittest.TestCase):
         idx = np.array([2, 1, 3])
         dest = np.zeros((len(idx), 100), dtype='float32')
         with self.assertRaises(ValueError):
-            ts.extract(dest, idx)
+            ts.extract(dest, None, idx)
 
+        #Injection test.
+        ts = _get_ts()
+        src_i = np.array([2, 1, 3])
+        dest_i = np.array([0, 4, 2])
+        dest = np.zeros((5, 100), dtype='float32')
+        ts.extract(dest, dest_i, src_i)
+        np.testing.assert_array_equal(dest[dest_i], ts.data[src_i])
+        self.assertEqual(True, np.all(dest[[1, 3]] == 0))
 
     # Support functions
 


### PR DESCRIPTION
Enables selective extraction of detectors and sample range from a G3SuperTimestream.  Implements #102 .

Follow-up PR in sotodlib will make this the preferred extraction method in the book loader.