### PR TITLE
C++: BufferWrapper fixes (and fix propagation of exception text)

### DIFF
--- a/include/exceptions.h
+++ b/include/exceptions.h
@@ -15,7 +15,7 @@ public:
     so3g_exception(std::string text) :
         text{text} {}
 
-    std::string msg_for_python() const throw() {
+    virtual std::string msg_for_python() const throw() {
         return text;
     }
 };

--- a/src/Projection.cxx
+++ b/src/Projection.cxx
@@ -505,12 +505,12 @@ public:
     bool TestInputs(bp::object &map, bool need_map, bool need_weight_map, int comp_count) {
         if (need_map) {
             // The map is mandatory, and the leading axis must match the
-            // component count.  It can have 1+ other dimensions.
+            // component count.  Then the one healpix pixel axis.
             mapbuf = BufferWrapper<double>("map", map, false,
                                            vector<int>{comp_count,-1});
         } else if (need_weight_map) {
             // The map is mandatory, and the two leading axes must match
-            // the component count.  It can have 1+ other dimensions.
+            // the component count.  Then the one healpix pixel axis.
             mapbuf = BufferWrapper<double>("map", map, false,
                                            vector<int>{comp_count,comp_count,-1});
         }
@@ -791,14 +791,14 @@ public:
     bool TestInputs(bp::object &map, bool need_map, bool need_weight_map, int comp_count) {
         if (need_map) {
             // The map is mandatory, and the leading axis must match the
-            // component count.  It can have 1+ other dimensions.
+            // component count.  And then 2 celestial axes.
             mapbuf = BufferWrapper<double>("map", map, false,
-                                           vector<int>{comp_count,-1,-3});
+                                           vector<int>{comp_count,-1,-1});
         } else if (need_weight_map) {
             // The map is mandatory, and the two leading axes must match
-            // the component count.  It can have 1+ other dimensions.
+            // the component count.  And then 2 celestial axes.
             mapbuf = BufferWrapper<double>("map", map, false,
-                                           vector<int>{comp_count,comp_count,-1,-3});
+                                           vector<int>{comp_count,comp_count,-1,-1});
         }
         return true;
     }
@@ -980,12 +980,12 @@ public:
         vector<int> map_shape_req;
         if (need_map) {
             // The map is mandatory, and the leading axis must match the
-            // component count.  It can have 1+ other dimensions.
-            map_shape_req = {comp_count,-1,-3};
+            // component count.  And then 2 celestial axes.
+            map_shape_req = {comp_count,-1,-1};
         } else if (need_weight_map) {
             // The map is mandatory, and the two leading axes must match
-            // the component count.  It can have 1+ other dimensions.
-            map_shape_req = {comp_count,comp_count,-1,-3};
+            // the component count.  And then 2 celestial axes.
+            map_shape_req = {comp_count,comp_count,-1,-1};
         }
         if (map_shape_req.size() == 0)
             return true;
@@ -2125,7 +2125,7 @@ bp::object ProjEng_Precomp<TilingSys>::to_weight_map(
     // Unlike the on-the-fly class, we aren't able to make the map
     // here, because there's no initialized pixelizor.
     auto pixelizor = Pixelizor2_Flat<TilingSys>();
-    pixelizor.TestInputs(map, true, false, n_spin);
+    pixelizor.TestInputs(map, false, true, n_spin);
 
     BufferWrapper<FSIGNAL> _det_weights("det_weights", det_weights, true,
                                         vector<int>{n_det});

--- a/src/Projection.cxx
+++ b/src/Projection.cxx
@@ -507,12 +507,12 @@ public:
             // The map is mandatory, and the leading axis must match the
             // component count.  Then the one healpix pixel axis.
             mapbuf = BufferWrapper<double>("map", map, false,
-                                           vector<int>{comp_count,-1});
+                                           vector<int>{comp_count,npix});
         } else if (need_weight_map) {
             // The map is mandatory, and the two leading axes must match
             // the component count.  Then the one healpix pixel axis.
             mapbuf = BufferWrapper<double>("map", map, false,
-                                           vector<int>{comp_count,comp_count,-1});
+                                           vector<int>{comp_count,comp_count,npix});
         }
         return true;
     }
@@ -651,12 +651,12 @@ public:
         vector<int> map_shape_req;
         if (need_map) {
             // The map is mandatory, and the leading axis must match the
-            // component count.  It can have 1+ other dimensions.
-            map_shape_req = {comp_count,-1};
+            // component count, second axis the npix_per_tile.
+            map_shape_req = {comp_count,npix_per_tile};
         } else if (need_weight_map) {
             // The map is mandatory, and the two leading axes must match
-            // the component count.  It can have 1+ other dimensions.
-            map_shape_req = {comp_count,comp_count,-1};
+            // the component count.
+            map_shape_req = {comp_count,comp_count,npix_per_tile};
         }
         if (map_shape_req.size() == 0)
             return true;

--- a/src/array_ops.cxx
+++ b/src/array_ops.cxx
@@ -555,6 +555,18 @@ void get_gap_fill_poly(const bp::object ranges,
     free(a);
 }
 
+
+void test_buffer_wrapper(const bp::object array,
+                         const bp::object dims)
+{
+    std::vector<int> _dims(bp::len(dims));
+    for (int i=0; i<bp::len(dims); i++)
+        _dims[i] = bp::extract<double>(dims[i]);
+    BufferWrapper<double> array_buf  ("array",  array,  false, _dims);
+
+}
+
+
 PYBINDINGS("so3g")
 {
     bp::def("nmat_detvecs_apply", nmat_detvecs_apply);
@@ -579,4 +591,6 @@ PYBINDINGS("so3g")
             "Do polynomial gap-filling for float64 data.\n"
             "\n"
             "See details in docstring for get_gap_fill_poly.\n");
+    bp::def("test_buffer_wrapper", test_buffer_wrapper,
+            "Pass array and list of dims to match against its shape.");
 }

--- a/test/test_array_ops.py
+++ b/test/test_array_ops.py
@@ -43,6 +43,31 @@ class TestPolyFill(unittest.TestCase):
             np.testing.assert_allclose(BAD_DATA, ex, rtol=tolerance)
 
 
+class TestBufferWrapper(unittest.TestCase):
+    def test_00(self):
+        for array_shape, pattern in [
+                ((2, 4), (2, 4)),
+                ((2, 4), (-1, -1)),
+                ((2, 4), (-2,)),
+                ((2, 4), (-1, -1, -2,)),
+                ((2, 4), (-2, -1, -1)),
+                ((2, 4), (-1, -2, -1)),
+        ]:
+            a = np.zeros(array_shape)
+            so3g.test_buffer_wrapper(a, list(pattern))
+
+        for array_shape, pattern in [
+                ((2, 4), (-2, -2)),
+                ((2, 4), (2,)),
+                ((2, 4), (4,)),
+                ((2, 4), (2, 3)),
+                ((2, 4), (2, 4, -1)),
+                ((2, 4), (2, -1, -1)),
+                ((2, 4), (-1, -1, -1, -2)),
+        ]:
+            a = np.zeros(array_shape)
+            with self.assertRaises(RuntimeError):
+                so3g.test_buffer_wrapper(a, list(pattern))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_proj_eng.py
+++ b/test/test_proj_eng.py
@@ -64,6 +64,10 @@ class TestProjEng(unittest.TestCase):
             w = p.to_weights(asm, comps=comps)[0, 0]
             assert(np.any(w != 0))
 
+        target = np.zeros((1, ) + m.shape[:-1])
+        with self.assertRaises(RuntimeError):
+            p.to_map(sig, asm, comps='T', output=target)
+
         # Does det_weights seem to work?
         m = p.to_map(sig, asm, comps='T',
                      det_weights=np.array([0., 0.], dtype='float32'))[0]


### PR DESCRIPTION
Fixes how array shapes are checked by BufferWrapper (which emerged in #179) ... and tests for that, and additional consequences.

Addresses #182