### PR TITLE
Fix wheel build

### DIFF
--- a/.github/workflows/official-docker-images.yml
+++ b/.github/workflows/official-docker-images.yml
@@ -24,7 +24,7 @@ jobs:
     # Build
     - name: Build docker images
       run: |
-        docker-compose build
+        docker compose build
 
     # Test (already been run by pytest workflow, but they don't take long...)
     - name: Test with pytest within a docker container
@@ -54,10 +54,10 @@ jobs:
         export DOCKER_TAG=`git describe --tags --always`
 
         # Tag all images for upload to the registry
-        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${DOCKERHUB_ORG}/{}:latest
-        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}
+        docker compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${DOCKERHUB_ORG}/{}:latest
+        docker compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}
 
         # Upload to docker registry
-        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${DOCKERHUB_ORG}/{}:latest
-        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}
-        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} echo ${DOCKERHUB_ORG}/{}:${DOCKER_TAG} pushed
+        docker compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${DOCKERHUB_ORG}/{}:latest
+        docker compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}
+        docker compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} echo ${DOCKERHUB_ORG}/{}:${DOCKER_TAG} pushed

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Build docker images
       run: |
-        docker-compose build
+        docker compose build
 
     - name: Test with pytest within a docker container
       run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -80,16 +80,16 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.10'
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.15.0
+          python -m pip install cibuildwheel==2.19.2
 
       - name: Build wheel
         run: |

--- a/setup.py
+++ b/setup.py
@@ -373,7 +373,7 @@ conf["version"] = get_version()
 conf["python_requires"] = ">=3.7.0"
 conf["setup_requires"] = (["wheel", "cmake"],)
 conf["install_requires"] = [
-    "numpy",
+    "numpy<2",
     "astropy",
     "matplotlib",
     "scipy",

--- a/wheels/install_deps_linux.sh
+++ b/wheels/install_deps_linux.sh
@@ -33,7 +33,7 @@ PREFIX=/usr/local
 pip install --upgrade pip
 
 # Install a couple of base packages that are always required
-pip install -v cmake wheel
+pip install -v cmake wheel setuptools
 
 # In order to maximize ABI compatibility with numpy, build with the newest numpy
 # version containing the oldest ABI version compatible with the python we are using.

--- a/wheels/install_deps_osx.sh
+++ b/wheels/install_deps_osx.sh
@@ -53,7 +53,7 @@ fi
 pip install --upgrade pip
 
 # Install a couple of base packages that are always required
-pip install -v cmake wheel
+pip install -v cmake wheel setuptools
 
 # In order to maximize ABI compatibility with numpy, build with the newest numpy
 # version containing the oldest ABI version compatible with the python we are using.

--- a/wheels/spt3g.patch
+++ b/wheels/spt3g.patch
@@ -1,11 +1,38 @@
 diff -urN spt3g_software_orig/cmake/Spt3gBoostPython.cmake spt3g_software/cmake/Spt3gBoostPython.cmake
---- spt3g_software_orig/cmake/Spt3gBoostPython.cmake	2022-11-09 12:55:44.950643068 -0800
-+++ spt3g_software/cmake/Spt3gBoostPython.cmake	2022-11-09 12:59:23.391502813 -0800
-@@ -1,6 +1,6 @@
+--- spt3g_software_orig/cmake/Spt3gBoostPython.cmake	2024-08-22 10:25:14.077183587 -0700
++++ spt3g_software/cmake/Spt3gBoostPython.cmake	2024-08-22 10:27:10.956608507 -0700
+@@ -1,7 +1,7 @@
  # Locate Python
+ 
  if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.12)
 -	find_package(Python COMPONENTS Interpreter Development)
 +	find_package(Python COMPONENTS Interpreter)
  else()
  	find_package(PythonInterp)
  	find_package(PythonLibs ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
+diff -urN spt3g_software_orig/core/CMakeLists.txt spt3g_software/core/CMakeLists.txt
+--- spt3g_software_orig/core/CMakeLists.txt	2024-08-06 11:34:45.598647939 -0700
++++ spt3g_software/core/CMakeLists.txt	2024-08-22 10:29:17.655985088 -0700
+@@ -105,8 +105,8 @@
+ add_spt3g_test(quaternions)
+ add_spt3g_test(timesample)
+ 
+-add_spt3g_test_program(test
+-                       SOURCE_FILES
+-                         ${CMAKE_CURRENT_SOURCE_DIR}/tests/G3TimestreamTest.cxx
+-                         ${CMAKE_CURRENT_SOURCE_DIR}/tests/G3TimestreamMapTest.cxx
+-                       USE_PROJECTS core)
++#add_spt3g_test_program(test
++#                       SOURCE_FILES
++#                         ${CMAKE_CURRENT_SOURCE_DIR}/tests/G3TimestreamTest.cxx
++#                         ${CMAKE_CURRENT_SOURCE_DIR}/tests/G3TimestreamMapTest.cxx
++#                       USE_PROJECTS core)
+diff -urN spt3g_software_orig/examples/CMakeLists.txt spt3g_software/examples/CMakeLists.txt
+--- spt3g_software_orig/examples/CMakeLists.txt	2024-08-06 11:34:45.610647890 -0700
++++ spt3g_software/examples/CMakeLists.txt	2024-08-22 10:56:07.300059646 -0700
+@@ -1,2 +1,2 @@
+-add_executable(cppexample cppexample.cxx) 
+-target_link_libraries(cppexample core)
++#add_executable(cppexample cppexample.cxx) 
++#target_link_libraries(cppexample core)
+Binary files spt3g_software_orig/.git/index and spt3g_software/.git/index differ

--- a/wheels/test_local_cibuildwheel.sh
+++ b/wheels/test_local_cibuildwheel.sh
@@ -3,7 +3,9 @@
 # Before running this from the so3g git checkout directory,
 # you should pip install cibuildwheel
 
-export CIBW_BUILD="cp39-manylinux_x86_64"
+export CIBW_DEBUG_KEEP_CONTAINER=TRUE
+
+export CIBW_BUILD="cp310-manylinux_x86_64"
 export CIBW_MANYLINUX_X86_64_IMAGE="manylinux2014"
 export CIBW_BUILD_VERBOSITY=3
 export CIBW_ENVIRONMENT_LINUX="CC=gcc CXX=g++ CFLAGS='-O3 -g -fPIC' CXXFLAGS='-O3 -g -fPIC -std=c++14'"


### PR DESCRIPTION
This updates some of the actions, bumps the version of cibuildwheel, and updates the spt3g patch to disable compiled executables.