### PR TITLE
Implement linear interpolation function with GSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(Spt3g REQUIRED)
 find_package(PythonInterp 3)
 find_package(PythonLibs 3)
 find_package(FLAC)
+find_package(GSL)
 
 find_package(OpenMP)
 if(OPENMP_FOUND)
@@ -83,6 +84,9 @@ file(GLOB MY_PYTHONS_SMURF
 
 # Provide list of libs to link against.
 target_link_libraries(so3g spt3g::core)
+# Link GSL
+target_include_directories(so3g PRIVATE ${GSL_INCLUDE_DIR})
+target_link_libraries(so3g ${GSL_LIBRARIES})
 
 # You probably want to select openblas, so pass -DBLA_VENDOR=OpenBLAS
 find_package(BLAS REQUIRED)

--- a/src/array_ops.cxx
+++ b/src/array_ops.cxx
@@ -868,7 +868,7 @@ void _interp1d(const bp::object & x, const bp::object & y, const bp::object & x_
 {
     BufferWrapper<T> y_buf  ("y",  y,  false, std::vector<int>{-1, -1});
     if (y_buf->strides[1] != y_buf->itemsize)
-        throw ValueError_exception("Argument 'y' must be a C-contiguous 2d array.");
+        throw ValueError_exception("Argument 'y' must be must be contiguous in last axis.");
     T* y_data = (T*)y_buf->buf;
     const int n_rows = y_buf->shape[0];
     const int n_x = y_buf->shape[1];
@@ -880,7 +880,7 @@ void _interp1d(const bp::object & x, const bp::object & y, const bp::object & x_
 
     BufferWrapper<T> y_interp_buf  ("y_interp",  y_interp,  false, std::vector<int>{n_rows, -1});
     if (y_interp_buf->strides[1] != y_interp_buf->itemsize)
-        throw ValueError_exception("Argument 'y_interp' must be a C-contiguous 2d array.");
+        throw ValueError_exception("Argument 'y_interp' must be contiguous in last axis.");
     T* y_interp_data = (T*)y_interp_buf->buf;
     const int n_x_interp = y_interp_buf->shape[1];
 

--- a/src/array_ops.cxx
+++ b/src/array_ops.cxx
@@ -868,7 +868,7 @@ void _interp1d(const bp::object & x, const bp::object & y, const bp::object & x_
 {
     BufferWrapper<T> y_buf  ("y",  y,  false, std::vector<int>{-1, -1});
     if (y_buf->strides[1] != y_buf->itemsize)
-        throw ValueError_exception("Argument 'y' must be must be contiguous in last axis.");
+        throw ValueError_exception("Argument 'y' must be contiguous in last axis.");
     T* y_data = (T*)y_buf->buf;
     const int n_rows = y_buf->shape[0];
     const int n_x = y_buf->shape[1];

--- a/src/array_ops.cxx
+++ b/src/array_ops.cxx
@@ -15,6 +15,7 @@ extern "C" {
 }
 
 #include <boost/python.hpp>
+#include <gsl/gsl_spline.h>
 
 #include <pybindings.h>
 #include "so3g_numpy.h"
@@ -861,13 +862,12 @@ void _gsl_interp(double* x, double* y, double* x_interp, T* y_interp, int n_x, i
 template <typename T>
 void gsl_linear_interp(const bp::object & x, const bp::object & y, const bp::object & x_interp, bp::object & y_interp)
 {
-
     BufferWrapper<T> y_buf  ("y",  y,  false, std::vector<int>{-1, -1});
     int n_rows = y_buf->shape[0];
     int n_x = y_buf->shape[1];
 
     T* y_data = (T*)y_buf->buf;
-    
+
     BufferWrapper<T> x_buf  ("x",  x,  false, std::vector<int>{n_x});
     T* x_data = (T*)x_buf->buf;
 

--- a/test/test_array_ops.py
+++ b/test/test_array_ops.py
@@ -4,7 +4,7 @@ import so3g
 import numpy as np
 
 from scipy.interpolate import interp1d
-from scipy.signal import welch
+from scipy.signal import welch, windows
 
 class TestPolyFill(unittest.TestCase):
     """Test the polynomial gap filling."""
@@ -257,7 +257,7 @@ class TestGslInterpolate(unittest.TestCase):
         so3g.interp1d_linear(t[slice_offset:], sig[:,slice_offset:], t_interp[interp_slice_offset:], so3g_sig[:,interp_slice_offset:])
 
         tolerance = 1e-4
-        np.testing.assert_allclose(scipy_sig, so3g_sig[:,interp_slice_offset:], rtol=tolerance)       
+        np.testing.assert_allclose(scipy_sig, so3g_sig[:,interp_slice_offset:], rtol=tolerance)
 
 
 if __name__ == "__main__":

--- a/test/test_array_ops.py
+++ b/test/test_array_ops.py
@@ -110,5 +110,120 @@ class TestJumps(unittest.TestCase):
         np.testing.assert_array_equal(flagged, np.arange(50, 60))
 
 
+class TestGslInterpolate(unittest.TestCase):
+    """
+    Test linear interpolation using GSL.
+    """
+
+    def test_00_basic_interp_float32(self):
+        t_start = 0
+        t_end = 999
+        t_size = 500
+
+        t_interp_start = 0
+        t_interp_end = 999
+        t_interp_size = 2000
+
+        ndet = 3
+        dtype = 'float32'
+
+        t = np.linspace(t_start, t_end, t_size, dtype=dtype)
+        sig = np.array([(i + 1) * np.sin(2*np.pi*0.01*t + i) for i in range(ndet)],dtype=dtype)
+
+        t_interp = np.linspace(t_interp_start, t_interp_end, t_interp_size, dtype=dtype)
+
+        f_template = interp1d(t, sig, fill_value='extrapolate')
+        scipy_sig = f_template(t_interp)
+
+        so3g_sig = np.zeros([ndet, t_interp_size], dtype=dtype)
+        so3g.gsl_linear_interp(t, sig, t_interp, so3g_sig)
+
+        tolerance = 1e-4
+        np.testing.assert_allclose(scipy_sig, so3g_sig, rtol=tolerance)
+
+    def test_01_basic_interp_float64(self):
+        t_start = 0
+        t_end = 999
+        t_size = 500
+
+        t_interp_start = 0
+        t_interp_end = 999
+        t_interp_size = 2000
+
+        ndet = 3
+        dtype = 'float64'
+
+        t = np.linspace(t_start, t_end, t_size, dtype=dtype)
+        sig = np.array([(i + 1) * np.sin(2*np.pi*0.01*t + i) for i in range(ndet)],dtype=dtype)
+
+        t_interp = np.linspace(t_interp_start, t_interp_end, t_interp_size, dtype=dtype)
+
+        f_template = interp1d(t, sig, fill_value='extrapolate')
+        scipy_sig = f_template(t_interp)
+
+        so3g_sig = np.zeros([ndet, t_interp_size], dtype=dtype)
+        so3g.gsl_linear_interp64(t, sig, t_interp, so3g_sig)
+
+        tolerance = 1e-10
+        np.testing.assert_allclose(scipy_sig, so3g_sig, rtol=tolerance)
+
+    def test_02_linear_extrapolation(self):
+        t_start = 0.
+        t_end = 999.
+        t_size = 500
+
+        t_interp_start = -10.0
+        t_interp_end = 1009.
+        t_interp_size = 2000
+
+        ndet = 3
+        dtype = 'float32'
+
+        t = np.linspace(t_start, t_end, t_size, dtype=dtype)
+        sig = np.array([(i + 1) * np.sin(2*np.pi*0.01*t + i) for i in range(ndet)],dtype=dtype)
+
+        t_interp = np.linspace(t_interp_start, t_interp_end, t_interp_size, dtype=dtype)
+
+        f_template = interp1d(t, sig, fill_value='extrapolate')
+        scipy_sig = f_template(t_interp)
+
+        so3g_sig = np.zeros((ndet, t_interp_size), dtype=dtype)
+        so3g.gsl_linear_interp(t, sig, t_interp, so3g_sig)
+
+        tolerance = 1e-4
+        np.testing.assert_allclose(scipy_sig, so3g_sig, rtol=tolerance)
+
+    def test_03_uneven_spacing(self):
+        t_start = 0.
+        t_end = 999.
+        t_size = 500
+
+        t_interp_start = 0.
+        t_interp_end = 999.
+        t_interp_size = 2000
+
+        ndet = 3
+        dtype = 'float32'
+
+        # generate uneven spaced time samples with power law
+        t_pow = 1.3
+
+        t = np.linspace(t_start**(1/t_pow), t_end**(1/t_pow), t_size, dtype=dtype)
+        t = t**t_pow
+        sig = np.array([(i + 1) * np.sin(2*np.pi*0.01*t + i) for i in range(ndet)],dtype=dtype)
+
+        t_interp = np.linspace(t_interp_start**(1/t_pow), t_interp_end**(1/t_pow), t_interp_size, dtype=dtype)
+        t_interp = t_interp**t_pow
+
+        f_template = interp1d(t, sig, fill_value='extrapolate')
+        scipy_sig = f_template(t_interp)
+
+        so3g_sig = np.zeros((ndet, t_interp_size), dtype=dtype)
+        so3g.gsl_linear_interp(t, sig, t_interp, so3g_sig)
+
+        tolerance = 1e-4
+        np.testing.assert_allclose(scipy_sig, so3g_sig, rtol=tolerance)
+
+        
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_array_ops.py
+++ b/test/test_array_ops.py
@@ -139,7 +139,7 @@ class TestGslInterpolate(unittest.TestCase):
         scipy_sig = f_template(t_interp)
 
         so3g_sig = np.zeros([ndet, t_interp_size], dtype=dtype, order=order)
-        so3g.gsl_interp1d_linear(t, sig, t_interp, so3g_sig)
+        so3g.interp1d_linear(t, sig, t_interp, so3g_sig)
 
         tolerance = 1e-4
         np.testing.assert_allclose(scipy_sig, so3g_sig, rtol=tolerance)
@@ -166,7 +166,7 @@ class TestGslInterpolate(unittest.TestCase):
         scipy_sig = f_template(t_interp)
 
         so3g_sig = np.zeros([ndet, t_interp_size], dtype=dtype, order=order)
-        so3g.gsl_interp1d_linear64(t, sig, t_interp, so3g_sig)
+        so3g.interp1d_linear(t, sig, t_interp, so3g_sig)
 
         tolerance = 1e-10
         np.testing.assert_allclose(scipy_sig, so3g_sig, rtol=tolerance)
@@ -193,7 +193,7 @@ class TestGslInterpolate(unittest.TestCase):
         scipy_sig = f_template(t_interp)
 
         so3g_sig = np.zeros((ndet, t_interp_size), dtype=dtype, order=order)
-        so3g.gsl_interp1d_linear(t, sig, t_interp, so3g_sig)
+        so3g.interp1d_linear(t, sig, t_interp, so3g_sig)
 
         tolerance = 1e-4
         np.testing.assert_allclose(scipy_sig, so3g_sig, rtol=tolerance)
@@ -225,7 +225,7 @@ class TestGslInterpolate(unittest.TestCase):
         scipy_sig = f_template(t_interp)
 
         so3g_sig = np.zeros((ndet, t_interp_size), dtype=dtype, order=order)
-        so3g.gsl_interp1d_linear(t, sig, t_interp, so3g_sig)
+        so3g.interp1d_linear(t, sig, t_interp, so3g_sig)
 
         tolerance = 1e-4
         np.testing.assert_allclose(scipy_sig, so3g_sig, rtol=tolerance)

--- a/test/test_array_ops.py
+++ b/test/test_array_ops.py
@@ -127,17 +127,18 @@ class TestGslInterpolate(unittest.TestCase):
         t_interp_size = 2000
 
         ndet = 3
-        dtype = 'float32'
+        dtype = "float32"
+        order = "C"
 
         t = np.linspace(t_start, t_end, t_size, dtype=dtype)
-        sig = np.array([(i + 1) * np.sin(2*np.pi*0.01*t + i) for i in range(ndet)],dtype=dtype)
+        sig = np.array([(i + 1) * np.sin(2*np.pi*0.01*t + i) for i in range(ndet)],dtype=dtype, order=order)
 
         t_interp = np.linspace(t_interp_start, t_interp_end, t_interp_size, dtype=dtype)
 
         f_template = interp1d(t, sig, fill_value='extrapolate')
         scipy_sig = f_template(t_interp)
 
-        so3g_sig = np.zeros([ndet, t_interp_size], dtype=dtype)
+        so3g_sig = np.zeros([ndet, t_interp_size], dtype=dtype, order=order)
         so3g.gsl_linear_interp(t, sig, t_interp, so3g_sig)
 
         tolerance = 1e-4
@@ -153,17 +154,18 @@ class TestGslInterpolate(unittest.TestCase):
         t_interp_size = 2000
 
         ndet = 3
-        dtype = 'float64'
+        dtype = "float64"
+        order = "C"
 
         t = np.linspace(t_start, t_end, t_size, dtype=dtype)
-        sig = np.array([(i + 1) * np.sin(2*np.pi*0.01*t + i) for i in range(ndet)],dtype=dtype)
+        sig = np.array([(i + 1) * np.sin(2*np.pi*0.01*t + i) for i in range(ndet)],dtype=dtype, order=order)
 
         t_interp = np.linspace(t_interp_start, t_interp_end, t_interp_size, dtype=dtype)
 
         f_template = interp1d(t, sig, fill_value='extrapolate')
         scipy_sig = f_template(t_interp)
 
-        so3g_sig = np.zeros([ndet, t_interp_size], dtype=dtype)
+        so3g_sig = np.zeros([ndet, t_interp_size], dtype=dtype, order=order)
         so3g.gsl_linear_interp64(t, sig, t_interp, so3g_sig)
 
         tolerance = 1e-10
@@ -179,17 +181,18 @@ class TestGslInterpolate(unittest.TestCase):
         t_interp_size = 2000
 
         ndet = 3
-        dtype = 'float32'
+        dtype = "float32"
+        order = "C"
 
         t = np.linspace(t_start, t_end, t_size, dtype=dtype)
-        sig = np.array([(i + 1) * np.sin(2*np.pi*0.01*t + i) for i in range(ndet)],dtype=dtype)
+        sig = np.array([(i + 1) * np.sin(2*np.pi*0.01*t + i) for i in range(ndet)],dtype=dtype, order=order)
 
         t_interp = np.linspace(t_interp_start, t_interp_end, t_interp_size, dtype=dtype)
 
         f_template = interp1d(t, sig, fill_value='extrapolate')
         scipy_sig = f_template(t_interp)
 
-        so3g_sig = np.zeros((ndet, t_interp_size), dtype=dtype)
+        so3g_sig = np.zeros((ndet, t_interp_size), dtype=dtype, order=order)
         so3g.gsl_linear_interp(t, sig, t_interp, so3g_sig)
 
         tolerance = 1e-4
@@ -205,14 +208,15 @@ class TestGslInterpolate(unittest.TestCase):
         t_interp_size = 2000
 
         ndet = 3
-        dtype = 'float32'
+        dtype = "float32"
+        order = "C"
 
         # generate uneven spaced time samples with power law
         t_pow = 1.3
 
         t = np.linspace(t_start**(1/t_pow), t_end**(1/t_pow), t_size, dtype=dtype)
         t = t**t_pow
-        sig = np.array([(i + 1) * np.sin(2*np.pi*0.01*t + i) for i in range(ndet)],dtype=dtype)
+        sig = np.array([(i + 1) * np.sin(2*np.pi*0.01*t + i) for i in range(ndet)],dtype=dtype, order=order)
 
         t_interp = np.linspace(t_interp_start**(1/t_pow), t_interp_end**(1/t_pow), t_interp_size, dtype=dtype)
         t_interp = t_interp**t_pow
@@ -220,7 +224,7 @@ class TestGslInterpolate(unittest.TestCase):
         f_template = interp1d(t, sig, fill_value='extrapolate')
         scipy_sig = f_template(t_interp)
 
-        so3g_sig = np.zeros((ndet, t_interp_size), dtype=dtype)
+        so3g_sig = np.zeros((ndet, t_interp_size), dtype=dtype, order=order)
         so3g.gsl_linear_interp(t, sig, t_interp, so3g_sig)
 
         tolerance = 1e-4

--- a/test/test_array_ops.py
+++ b/test/test_array_ops.py
@@ -3,6 +3,8 @@ import unittest
 import so3g
 import numpy as np
 
+from scipy.interpolate import interp1d
+
 
 class TestPolyFill(unittest.TestCase):
     """Test the polynomial gap filling."""

--- a/test/test_array_ops.py
+++ b/test/test_array_ops.py
@@ -114,10 +114,10 @@ class TestJumps(unittest.TestCase):
 
 class TestGslInterpolate(unittest.TestCase):
     """
-    Test linear interpolation using GSL.
+    Test interpolation using GSL.
     """
 
-    def test_00_basic_interp_float32(self):
+    def test_00_linear_interp_float32(self):
         t_start = 0
         t_end = 999
         t_size = 500
@@ -139,12 +139,12 @@ class TestGslInterpolate(unittest.TestCase):
         scipy_sig = f_template(t_interp)
 
         so3g_sig = np.zeros([ndet, t_interp_size], dtype=dtype, order=order)
-        so3g.gsl_linear_interp(t, sig, t_interp, so3g_sig)
+        so3g.gsl_interp1d_linear(t, sig, t_interp, so3g_sig)
 
         tolerance = 1e-4
         np.testing.assert_allclose(scipy_sig, so3g_sig, rtol=tolerance)
 
-    def test_01_basic_interp_float64(self):
+    def test_01_linear_interp_float64(self):
         t_start = 0
         t_end = 999
         t_size = 500
@@ -166,7 +166,7 @@ class TestGslInterpolate(unittest.TestCase):
         scipy_sig = f_template(t_interp)
 
         so3g_sig = np.zeros([ndet, t_interp_size], dtype=dtype, order=order)
-        so3g.gsl_linear_interp64(t, sig, t_interp, so3g_sig)
+        so3g.gsl_interp1d_linear64(t, sig, t_interp, so3g_sig)
 
         tolerance = 1e-10
         np.testing.assert_allclose(scipy_sig, so3g_sig, rtol=tolerance)
@@ -193,7 +193,7 @@ class TestGslInterpolate(unittest.TestCase):
         scipy_sig = f_template(t_interp)
 
         so3g_sig = np.zeros((ndet, t_interp_size), dtype=dtype, order=order)
-        so3g.gsl_linear_interp(t, sig, t_interp, so3g_sig)
+        so3g.gsl_interp1d_linear(t, sig, t_interp, so3g_sig)
 
         tolerance = 1e-4
         np.testing.assert_allclose(scipy_sig, so3g_sig, rtol=tolerance)
@@ -225,7 +225,7 @@ class TestGslInterpolate(unittest.TestCase):
         scipy_sig = f_template(t_interp)
 
         so3g_sig = np.zeros((ndet, t_interp_size), dtype=dtype, order=order)
-        so3g.gsl_linear_interp(t, sig, t_interp, so3g_sig)
+        so3g.gsl_interp1d_linear(t, sig, t_interp, so3g_sig)
 
         tolerance = 1e-4
         np.testing.assert_allclose(scipy_sig, so3g_sig, rtol=tolerance)


### PR DESCRIPTION
This branch adds a simple parallelized linear interpolator using GSL.  Since `FindGSL.cmake` was already in SPT3G, only a few lines needed to be added to the so3g cmake file to include it.  I wrote it to mimic the output of `scipy.interpolate.interp1d` when `kind=linear` and `fill_value='extrapolation'`, which is the setup currently used in the sotodlib azss code.  

GSL has a few other interpolation options (linear, cspline, periodic cspline, non-rounded akima spline) which we can also write functions (or accept an interpolation kind argument maybe) for if we need them.  GSL does not handle extrapolation by itself, so the other options will likely need more careful handling of the extrapolation than what I've done here for now (as highlighted in this discussion: https://docs.scipy.org/doc/scipy/tutorial/interpolate/extrapolation_examples.html#extrapolation-tips-and-tricks).