### PR TITLE
Add detrend function

### DIFF
--- a/src/array_ops.cxx
+++ b/src/array_ops.cxx
@@ -1263,6 +1263,7 @@ PYBINDINGS("so3g")
             "       The data is modified in place.\n"
             "  method: how to detrend data.  Options are 'mean', 'median', and 'linear'. Linear calculates "
             "          and subtracts the slope from either end of each row as determined from 'linear_ncount'.\n"
-            "  linear_ncount: Number (int) of samples to use, on each end, when measuring mean level for 'linear'"
-            "                 detrend. Values larger than 1 suppress the influence of white noise.\n");
+            "  linear_ncount: Number (int) of samples to use on each end, when measuring mean level for 'linear'"
+            "                 detrend. Must be a positive integer or -1.  If -1, nsamps / 2 will be used. Values "
+            "                 larger than 1 suppress the influence of white noise.\n");
 }

--- a/src/array_ops.cxx
+++ b/src/array_ops.cxx
@@ -1013,7 +1013,7 @@ T _calculate_median(const T* data, const int n)
 template <typename T>
 void _detrend(T* data, const int ndets, const int nsamps, const int row_stride,
               const std::string & method, const int linear_ncount,
-              const int nthreads=1)
+              const int nthreads)
 {
     if (method == "mean") {
         #pragma omp parallel for num_threads(nthreads)
@@ -1129,7 +1129,7 @@ void _detrend_buffer(bp::object & tod, const std::string & method,
 
     // We want _detrend to accept C++ types so it can be used internally
     // for Welch psd calculations, hence the hierarchical function calls
-    _detrend<T>(tod_data, ndets, nsamps, row_stride, method, linear_ncount);
+    _detrend<T>(tod_data, ndets, nsamps, row_stride, method, linear_ncount, nthreads);
 }
 
 void detrend(bp::object & tod, const std::string & method, const int linear_ncount)


### PR DESCRIPTION
This branch adds a detrend function that duplicates the functionality in sotodlib's detrend_tod function for 1D or 2D arrays (sotodlib supports higher dimensions, but I haven't reproduced that here for now).  It has mean, median (using GSL median which is much faster than a std::sort approach), and linear detrending along the rows of an array.

This is primarily intended to be used in an upcoming Welch PSD function but is also standalone, so the underlying function can be run sequentially and called within a parallel loop inside another function (more efficient for the Welch PSD calculation).