### PR TITLE
Stokes response

### DIFF
--- a/demos/demo_proj2.py
+++ b/demos/demo_proj2.py
@@ -82,7 +82,7 @@ polphi[1::2] = polphi[0::2] + np.pi/2
 
 ptg = test_utils.get_boresight_quat(system, x*np.pi/180, y*np.pi/180)
 ofs = test_utils.get_offsets_quat(system, dx, dy, polphi)
-
+resp= np.ones((n_det,2),np.float32)
 
 #
 # Projection tests.
@@ -91,7 +91,7 @@ ofs = test_utils.get_offsets_quat(system, dx, dy, polphi)
 pe = test_utils.get_proj(system, 'TQU')(pxz)
 
 # Project the map into time-domain.
-sig0 = pe.from_map(beam, ptg, ofs, None)
+sig0 = pe.from_map(beam, ptg, ofs, resp, None)
 sig0 = np.array(sig0)
 
 # Add some noise...
@@ -118,10 +118,10 @@ else:
 # Then back to map.
 print('Create timestream...', end='\n ... ')
 with Timer():
-    map1 = pe.to_map(None, ptg, ofs, sig1, det_weights, None)
+    map1 = pe.to_map(None, ptg, ofs, resp, sig1, det_weights, None)
 
 # Get the weight map (matrix).
-wmap1 = pe.to_weight_map(None, ptg, ofs, det_weights, None)
+wmap1 = pe.to_weight_map(None, ptg, ofs, resp, det_weights, None)
 wmap1[1,0] = wmap1[0,1]  # fill in unpopulated entries...
 wmap1[2,0] = wmap1[0,2]
 wmap1[2,1] = wmap1[1,2]
@@ -151,6 +151,8 @@ if not args.no_plots:
 
 sigd = (sig1[0::2,:] - sig1[1::2,:]) / 2
 ofsd = (ofs[::2,...])
+respd= resp[::2]
+
 if not args.uniform_weights:
     det_weights = det_weights[::2]
 
@@ -160,12 +162,12 @@ pe = test_utils.get_proj(system, 'QU')(pxz)
 # Bin the map again...
 print('to map...', end='\n ... ')
 with Timer():
-    map1d = pe.to_map(None, ptg, ofsd, sigd, det_weights, None)
+    map1d = pe.to_map(None, ptg, ofsd, respd, sigd, det_weights, None)
 
 # Bin the weights again...
 print('to weight map...', end='\n ... ')
 with Timer():
-    wmap1d = pe.to_weight_map(None, ptg, ofsd, det_weights, None)
+    wmap1d = pe.to_weight_map(None, ptg, ofsd, respd, det_weights, None)
 
 wmap1d[1,0] = wmap1d[0,1] # fill in unpopulated entries again...
 

--- a/demos/demo_proj_hp.py
+++ b/demos/demo_proj_hp.py
@@ -191,13 +191,6 @@ def simulate_detectors(ndets, rmax, seed=0):
     eta = rr * np.sin(phi)
     return xi, eta, gamma
 
-def make_fp(xi, eta, gamma):
-    fp = so3g.proj.quat.rotation_xieta(xi, eta, gamma)
-    so3g_fp = so3g.proj.FocalPlane()
-    for i, q in enumerate(fp):
-        so3g_fp[f'a{i}'] = q
-    return so3g_fp
-
 def extract_coord(sight, fp, isignal=0, groupsize=100):
     coord_out = []
     for ii in range(0, len(fp), groupsize):
@@ -208,14 +201,14 @@ def extract_coord(sight, fp, isignal=0, groupsize=100):
 
 def make_signal(ndets, rmax, sight, isignal, seed=0):
     xi, eta, gamma = simulate_detectors(ndets, rmax, seed)
-    fp = so3g.proj.quat.rotation_xieta(xi, eta, gamma)
+    fp = so3g.proj.FocalPlane.from_xieta(xi, eta, gamma)
     signal = extract_coord(sight, fp, isignal)
     return signal
 
 def make_tod(time, az, el, ndets, rmax, isignal, seed=0):
     sight = so3g.proj.CelestialSightLine.naive_az_el(time, az, el)
     signal = make_signal(ndets, rmax, sight, isignal, seed)
-    so3g_fp = make_fp(*simulate_detectors(ndets, rmax, seed))
+    so3g_fp = so3g.proj.FocalPlane.from_xieta(*simulate_detectors(ndets, rmax, seed))
     asm = so3g.proj.Assembly.attach(sight, so3g_fp)
     return signal, asm
 

--- a/docs/proj.rst
+++ b/docs/proj.rst
@@ -85,9 +85,9 @@ quaternions into rotation angles::
   >>> csl.Q
   spt3g.core.G3VectorQuat([(-0.0384748,0.941783,0.114177,0.313891)])
 
-  >>> csl.coords()   
+  >>> csl.coords()
   array([[ 0.24261138, -0.92726871, -0.99999913, -0.00131952]])
-  
+
 The :func:`coords() <CelestialSightLine.coords>` returns an array with
 shape (n_time, 4); each 4-tuple contains values ``(lon, lat,
 cos(gamma), sin(gamma))``.  The ``lon`` and ``lat`` are the celestial
@@ -117,12 +117,12 @@ orientations::
 
 This particular function, :func:`from_xieta()
 <FocalPlane.from_xieta>`, will apply the SO standard coordinate
-definitions and stores quaternion coefficients (``.quats``) and
-responsivities (``.resps``) for each detectors. These are numpy
-arrays with shape ``[ndet,4]`` and ``[ndet,2]`` respectively.
-``fp.quats[0]`` gives the 4 quaternion coefficients for the
-first detector, while ``fp.resps[0]`` gives its total intensity
-and polarization responsivity.::
+definitions and stores quaternions (``.quats``) and
+responsivities (``.resps``) for each detector. These are a
+``G3VectorQuat``  wth length ``ndet`` and a numpy array
+with shape ``[ndet,2]`` respectively. ``fp.quats[0]`` gives
+the quaternion for the first detector, while ``fp.resps[0]``
+gives its total intensity and polarization responsivity.::
 
   >>> fp.quats[2]
   array([  0.86601716,  0.00377878, -0.00218168,  0.49999524])
@@ -133,7 +133,7 @@ As you can see, the default responsivity is 1 for both total
 intensty and polarization. Note that ``.quats`` contains
 quaternion *coefficients*, not quaternion *objects*. To do
 quaternion math, you need to convert them to actual quaternion
-objects, e.g. ``q = spt3g.core.quat(*fp.quats[0])``, or convert
+objects, e.g. ``q = fp.quats[0]``, or convert
 them all at once with ``qs = spt3g.core.G3VectorQuat(fp.quats)```.
 
 To represent detectors with responsivity different from 1,
@@ -166,7 +166,7 @@ At this point you could get the celestial coordinates for any one of
 those detectors::
 
   # Get vector of quaternion pointings for detector 0
-  q_total = csl.Q * spt3g.core.quat(*fp.quats[0])
+  q_total = csl.Q * fp.quats[0]
   # Decompose q_total into lon, lat, roll angles
   ra, dec, gamma = so3g.proj.quat.decompose_lonlat(q_total)
 
@@ -185,9 +185,8 @@ FocalPlane object as first argument::
    array([[ 0.24261138, -0.92726871,  0.86536489,  0.5011423 ]]),
    array([[ 0.22806774, -0.92722945,  0.50890634,  0.86082189]])]
 
-To be clear, ``coords()`` now returns a dictionary whose keys are the
-detector names.  Each value is an array with shape (n_time,4), and at
-each time step the 4 elements of the array are: ``(lon, lat,
+So ``coords()`` returns a list of numpy arrays with shape (n_time,4),
+and at each time step the 4 elements of the array are: ``(lon, lat,
 cos(gamma), sin(gamma))``.
 
 

--- a/docs/proj.rst
+++ b/docs/proj.rst
@@ -125,22 +125,16 @@ the quaternion for the first detector, while ``fp.resps[0]``
 gives its total intensity and polarization responsivity.::
 
   >>> fp.quats[2]
-  array([  0.86601716,  0.00377878, -0.00218168,  0.49999524])
+  spt3g.core.quat(0.866017,0.00377878,-0.00218168,0.499995)
   >>> fp.resps[2]
   array([1., 1.], dtype=float32)
 
 As you can see, the default responsivity is 1 for both total
-intensty and polarization. Note that ``.quats`` contains
-quaternion *coefficients*, not quaternion *objects*. To do
-quaternion math, you need to convert them to actual quaternion
-objects, e.g. ``q = fp.quats[0]``, or convert
-them all at once with ``qs = spt3g.core.G3VectorQuat(fp.quats)```.
-
-To represent detectors with responsivity different from 1,
-use the ``T`` and ``P`` arguments to :func:`from_xieta()`
-to set the total intensity and polarization responsivity
-respectively. These can be either single numbers or
-array-likes with lengths ``ndet``.::
+intensty and polarization. To represent detectors with
+responsivity different from 1, use the ``T`` and ``P``
+arguments to :func:`from_xieta()` to set the total intensity
+and polarization responsivity respectively. These can be
+either single numbers or array-likes with lengths ``ndet``.::
 
   xi  = np.array([-0.5, 0.0, 0.5]) * DEG
   eta = np.zeros(3)
@@ -157,7 +151,7 @@ specify these directly. The example above is equivalent to::
   xi  = np.array([-0.5, 0.0, 0.5]) * DEG
   eta = np.zeros(3)
   gamma = np.array([0,30,60]) * DEG
-  T   = np.array([1.0, 0.9])
+  T   = np.array([1.0, 0.9, 1.1])
   Q   = np.array([0.5, 0.3, -0.025])
   U   = np.array([0.0, 0.51961524, 0.04330127])
   fp2 = so3g.proj.FocalPlane.from_xieta(xi, eta, T=T, Q=Q, U=U)

--- a/docs/proj.rst
+++ b/docs/proj.rst
@@ -174,7 +174,7 @@ As expected, these coordinates are close to the ones computed before,
 for the boresight::
 
   >>> print(ra / DEG, dec / DEG)
-  [13.06731917] [-53.12633433]
+  [14.73387143] [-53.1250149]
 
 But the more expedient way to get pointing for multiple detectors is
 to call :func:`coords() <CelestialSightLine.coords>` with the
@@ -184,11 +184,6 @@ FocalPlane object as first argument::
   [array([[ 0.25715457, -0.92720643,  0.9999161 ,  0.01295328]]),
    array([[ 0.24261138, -0.92726871,  0.86536489,  0.5011423 ]]),
    array([[ 0.22806774, -0.92722945,  0.50890634,  0.86082189]])]
-
-  OrderedDict([('a', array([[ 0.22806774, -0.92722945, -0.9999468 ,
-  0.01031487]])), ('b', array([[ 0.24261138, -0.92726871, -0.86536489,
-  -0.5011423 ]])), ('c', array([[ 0.25715457, -0.92720643, -0.48874018,
-  -0.87242939]]))])
 
 To be clear, ``coords()`` now returns a dictionary whose keys are the
 detector names.  Each value is an array with shape (n_time,4), and at
@@ -256,17 +251,17 @@ from the pixels in pmap, which are the coordinates of the centers of
 the pixels::
 
   >>> [x/DEG for x in pix_ra]
-  [array([13.04], dtype=float32), array([13.88], dtype=float32), array([14.72], dtype=float32)]
+  [array([14.740001], dtype=float32), array([13.900001], dtype=float32), array([13.059999], dtype=float32)]
   >>> [x/DEG for x in pix_dec]
-  [array([-53.100002], dtype=float32), array([-53.100002], dtype=float32), array([-53.100002], dtype=float32)]
+  [array([-53.12], dtype=float32), array([-53.12], dtype=float32), array([-53.12], dtype=float32)]
 
 If you are not getting what you expect, you can grab the pixel indices
 inferred by the projector -- perhaps your pointing is taking you off
 the map (in which case the pixel indices would return value -1)::
 
   >>> p.get_pixels(asm)
-  [array([[ 45, 148]], dtype=int32), array([[ 45, 106]], dtype=int32),
-  array([[45, 64]], dtype=int32)]
+  [array([[44, 63]], dtype=int32), array([[ 44, 105]], dtype=int32),
+  array([[ 44, 147]], dtype=int32)]
 
 Let's project signal into an intensity map using
 :func:`Projectionist.to_map`::
@@ -281,9 +276,9 @@ Inspecting the map, we see our signal values occupy the three non-zero
 pixels:
 
   >>> map_out.nonzero()
-  (array([0, 0, 0]), array([45, 45, 45]), array([ 64, 106, 148]))
+  (array([0, 0, 0]), array([44, 44, 44]), array([ 63, 105, 147]))
   >>> map_out[map_out!=0]
-  array([100.,  10.,   1.])
+  array([  1.,  10., 100.])
 
 
 If we run this projection again, but pass in this map as a starting
@@ -292,7 +287,7 @@ point, the signal will be added to the map:
   >>> p.to_map(signal, asm, output=map_out, comps='T')
   array([[[0., 0., 0., ..., 0.]]])
   >>> map_out[map_out!=0]
-  array([200.,  20.,   2.])
+  array([  2.,  20., 200.])
 
 If we instead want to treat the signal as coming from
 polarization-sensitive detectors, we can request components
@@ -305,8 +300,8 @@ according to the projected detector angle on the sky::
 
   >>> map_pol.shape
   (3, 100, 200)
-  >>> map_pol[:,45,106]
-  array([10.        ,  4.97712803,  8.673419  ])
+  >>> map_pol[:,44,105]
+  array([10.,  4.97712803, 8.673419])
 
 For the most basic map-making, the other useful operation is the
 :func:`Projectionist.to_weights` method.  This is used to compute
@@ -330,7 +325,7 @@ the upper diagonal has been filled in, for efficiency reasons...::
 
   >>> weight_out.shape
   (3, 3, 100, 200)
-  >>> weight_out[...,45,106]
+  >>> weight_out[...,44,105]
   array([[1.        , 0.49771279, 0.86734194],
          [0.        , 0.24771802, 0.43168718],
          [0.        , 0.        , 0.75228202]])
@@ -393,7 +388,7 @@ Inspecting::
 
   >>> threads
   RangesMatrix(4,3,1)
-  >>> map_pol2[:,45,106]
+  >>> map_pol2[:,44,105]
   array([10.        ,  4.97712898,  8.67341805])
 
 The same ``threads`` result can be passed to ``p.to_weights``.

--- a/include/Projection.h
+++ b/include/Projection.h
@@ -48,17 +48,17 @@ public:
     bp::object pixels(bp::object pbore, bp::object pofs, bp::object pixel);
     vector<int> tile_hits(bp::object pbore, bp::object pofs);
     bp::object tile_ranges(bp::object pbore, bp::object pofs, bp::object tile_lists);
-    bp::object pointing_matrix(bp::object pbore, bp::object pofs,
+    bp::object pointing_matrix(bp::object pbore, bp::object pofs, bp::object response,
                                bp::object pixel, bp::object proj);
     bp::object zeros(bp::object shape);
     bp::object pixel_ranges(bp::object pbore, bp::object pofs, bp::object map, int n_domain=-1);
     bp::object from_map(bp::object map, bp::object pbore, bp::object pofs,
-                        bp::object signal);
-    bp::object to_map(bp::object map, bp::object pbore, bp::object pofs,
+                        bp::object response, bp::object signal);
+    bp::object to_map(bp::object map, bp::object pbore, bp::object pofs, bp::object response,
                       bp::object signal, bp::object det_weights,
                       bp::object thread_intervals);
     bp::object to_weight_map(bp::object map, bp::object pbore, bp::object pofs,
-                             bp::object det_weights, bp::object thread_intervals);
+                  bp::object response, bp::object det_weights, bp::object thread_intervals);
 
     int comp_count() const;
     int index_count() const;

--- a/python/proj/coords.py
+++ b/python/proj/coords.py
@@ -279,6 +279,9 @@ class FocalPlane:
     def ndet(self): return len(self.quats)
     def __getitem__(self, sel):
         return FocalPlane(quats=self.quats[sel], resps=self.resps[sel])
+    def items(self):
+        for q, resp in zip(quat.G3VectorQuat(self.quats), self.resps):
+            yield q, resp
 
 class Assembly:
     """This class groups together boresight and detector offset

--- a/python/proj/coords.py
+++ b/python/proj/coords.py
@@ -231,7 +231,7 @@ class CelestialSightLine:
             fplane = FocalPlane.boresight()
             if output is not None:
                 output = output[None]
-        output = p.coords(self.Q, fplane.quats), output)
+        output = p.coords(self.Q, fplane.quats, output)
         if collapse:
             output = output[0]
         return output

--- a/python/proj/coords.py
+++ b/python/proj/coords.py
@@ -242,7 +242,10 @@ class FocalPlane:
 
     Members:
      quats: Array of float64 with shape [ndet,4] representing the
-      pointing quaternions for each detector
+      pointing quaternions for each detector. Since these are just
+      plain coefficients, they will need to be converted to quaternion
+      objects if you want to do quaternion math with them, e.g.
+      G3VectorQuat(focal_plane.quats).
      resps: Array of float64 with shape [ndet,2] representing the
       total intensity and polarization responsivity of each detector
      ndet: The number of detectors (read-only)

--- a/python/proj/coords.py
+++ b/python/proj/coords.py
@@ -228,7 +228,7 @@ class CelestialSightLine:
         # Pre-process the offsets
         collapse = (fplane is None)
         if collapse:
-            fplane = FocalPlane()
+            fplane = FocalPlane.boresight()
             if output is not None:
                 output = output[None]
         output = p.coords(self.Q, fplane.quats, output)
@@ -261,6 +261,10 @@ class FocalPlane:
         # FIXME: old sotodlib compat - remove later
         self._dets   = list(dets) if dets is not None else []
         self._detmap = {name:i for i,name in enumerate(self._dets)}
+    @classmethod
+    def boresight(cls):
+        quats = np.array([[1,0,0,0]],np.float64)
+        return cls(quats=quats)
     @classmethod
     def from_xieta(cls, xi, eta, gamma=0, T=1, P=1, Q=1, U=0, hwp=False):
         # The underlying code wants polangle gamma and the T and P
@@ -357,7 +361,7 @@ class Assembly:
         """
         self = cls(collapse=True)
         self.Q = sight_line.Q
-        self.fplane = FocalPlane()
+        self.fplane = FocalPlane.boresight()
         return self
     # FIXME: old sotodlib compat - remove later
     @property

--- a/python/proj/coords.py
+++ b/python/proj/coords.py
@@ -240,11 +240,11 @@ class FocalPlane:
     """This class represents the detector positions and intensity and
     polarization responses in the focal plane.
 
-    Members:
+    Attributes:
      quats: G3VectorQuat representing the pointing quaternions for
       each detector. Can be turned into a numpy array of coefficients
       with np.array(). Or call .coeffs() to get them directly.
-     resps: Array of float64 with shape [ndet,2] representing the
+     resps: Array of float32 with shape [ndet,2] representing the
       total intensity and polarization responsivity of each detector
      ndet: The number of detectors (read-only)
 
@@ -300,8 +300,12 @@ class FocalPlane:
     @classmethod
     def from_xieta(cls, *args, **kwargs):
         """
-        def from_xieta(cls, xi, eta, gamma=0, T=1, P=1, Q=1, U=0, hwp=False):
+        ``from_xieta(cls, xi, eta, gamma=0, T=1, P=1, Q=1, U=0, hwp=False)``
         Construct a FocalPlane from focal plane coordinates (xi,eta).
+
+        For backwards compatibility, the signature
+        ``from_xieta(names, xi, eta, gamma=0)`` is also supported; but
+        this will be removed in the future.
 
         These are Cartesian projection plane coordinates. When looking
         at the sky along the telescope boresight, xi is parallel to

--- a/python/proj/coords.py
+++ b/python/proj/coords.py
@@ -320,24 +320,26 @@ class FocalPlane:
           2. Q and U
 
         Examples, assuming ndet = 2
-         * from_xieta(xi, eta, gamma=[0,pi/4])
+         * ``from_xieta(xi, eta, gamma=[0,pi/4])``
            Constructs a FocalPlane with T and P responsivity of 1
            and polarization angles of 0 and 45 degrees, representing
            a Q-sensitive and U-sensitive detector.
-         * from_xieta(xi, eta, gamma=[0,pi/4], P=0.5)
+         * ``from_xieta(xi, eta, gamma=[0,pi/4], P=0.5)``
            Like the above, but with a polarization responsivity of
            just 0.5.
-         * from_xieta(xi, eta, gamma=[0,pi/4], T=[1,0.9], P=[0.5,0.6])
+         * ``from_xieta(xi, eta, gamma=[0,pi/4], T=[1,0.9], P=[0.5,0.6])``
            Like above, but with a detector-dependent intensity and
-           polarization responsivity. T < P is valid, even though it
-           wouldn't make sense for most detector types.
-         * from_xieta(xi, eta, Q=[1,0], U=[0,1])
+           polarization responsivity. There is no restriction that
+           T > P. For the pseudo-detector timestreams one gets after
+           HWP demodulation, one would have T=0 for the cos-modulated
+           and sin-modulated timestreams, for example.
+         * ``from_xieta(xi, eta, Q=[1,0], U=[0,1])``
            Construct the FocalPlane with explicit Q and U responsivity.
            This example is equivalent to example 1.
 
         Usually one would either use gamma,P or Q,U. If they are
-        combined, then gamma_total = gamma + arctan2(U,Q)/2 and
-        P_tot = P * (Q**2+U**2)**0.5.
+        combined, then ``gamma_total = gamma + arctan2(U,Q)/2`` and
+        ``P_tot = P * (Q**2+U**2)**0.5``.
         """
         # The underlying code wants polangle gamma and the T and P
         # response, but we support speifying these as the T, Q and U
@@ -364,20 +366,20 @@ class FocalPlane:
     def __getitem__(self, sel):
         """Slice the FocalPlane with slice sel, resulting in a new
         FocalPlane with a subset of the detectors. Only 1d slice supported,
-        not integers or multidimensional slices. Example: focal_plane[10:20]
+        not integers or multidimensional slices. Example: ``focal_plane[10:20]``
         would make a sub-FocalPlane with detector indices 10,11,...,19.
 
         Deprecated: Temporarily also supports that sel is a detector name,
-        in which case an spt3g.core.quat is returned for that detector.
+        in which case an  ``spt3g.core.quat`` is returned for that detector.
         This is provided for backwards compatibility."""
         # FIXME: old sotodlib compat - remove later
         if isinstance(sel, str): return quat.G3VectorQuat(self.quats)[self._dets.index(sel)]
         return FocalPlane(quats=self.quats[sel], resps=self.resps[sel])
     def items(self):
         """Iterate over detector quaternions and responsivities. Yields
-        (spt3g.core.quat, array([Tresp,Presp])) pairs. Unlke the raw
+        ``(spt3g.core.quat, array([Tresp,Presp]))`` pairs. Unlke the raw
         entries in the .quats member, which are just numpy arrays with
-        length 4, spt3g.core.quat are proper quaternon objects that
+        length 4,  ``spt3g.core.quat`` are proper quaternon objects that
         support quaternion math.
         """
         for q, resp in zip(quat.G3VectorQuat(self.quats), self.resps):

--- a/python/proj/coords.py
+++ b/python/proj/coords.py
@@ -231,7 +231,7 @@ class CelestialSightLine:
             fplane = FocalPlane.boresight()
             if output is not None:
                 output = output[None]
-        output = p.coords(self.Q, fplane.coeffs(), output)
+        output = p.coords(self.Q, fplane.quats), output)
         if collapse:
             output = output[0]
         return output

--- a/python/proj/wcs.py
+++ b/python/proj/wcs.py
@@ -183,7 +183,7 @@ class _ProjectionistBase:
         """
         projeng = self.get_ProjEng('TQU')
         q_native = self._cache_q_fp_to_native(assembly.Q)
-        return projeng.pixels(q_native, assembly.fplane.coeffs(), None)
+        return projeng.pixels(q_native, assembly.fplane.quats, None)
 
     def get_pointing_matrix(self, assembly):
         """Get the pointing matrix information, which is to say both the pixel
@@ -199,7 +199,7 @@ class _ProjectionistBase:
         """
         projeng = self.get_ProjEng('TQU')
         q_native = self._cache_q_fp_to_native(assembly.Q)
-        return projeng.pointing_matrix(q_native, assembly.fplane.coeffs(), assembly.fplane.resps, None, None)
+        return projeng.pointing_matrix(q_native, assembly.fplane.quats, assembly.fplane.resps, None, None)
 
     def get_coords(self, assembly, use_native=False, output=None):
         """Get the spherical coordinates for the provided pointing Assembly.
@@ -225,7 +225,7 @@ class _ProjectionistBase:
             q_native = self._cache_q_fp_to_native(assembly.Q)
         else:
             q_native = assembly.Q
-        return projeng.coords(q_native, assembly.fplane.coeffs(), output)
+        return projeng.coords(q_native, assembly.fplane.quats, output)
 
     def get_planar(self, assembly, output=None):
         """Get projection plane coordinates for all detectors at all times.
@@ -240,7 +240,7 @@ class _ProjectionistBase:
         """
         q_native = self._cache_q_fp_to_native(assembly.Q)
         projeng = self.get_ProjEng('TQU')
-        return projeng.coords(q_native, assembly.fplane.coeffs(), output)
+        return projeng.coords(q_native, assembly.fplane.quats, output)
 
     def zeros(self, super_shape):
         """Return a map, filled with zeros, with shape (super_shape,) +
@@ -272,7 +272,7 @@ class _ProjectionistBase:
             comps = self._guess_comps(self._get_map_shape(output))
         projeng = self.get_ProjEng(comps)
         q_native = self._cache_q_fp_to_native(assembly.Q)
-        map_out = projeng.to_map(output, q_native, assembly.fplane.coeffs(),
+        map_out = projeng.to_map(output, q_native, assembly.fplane.quats,
             assembly.fplane.resps, signal, det_weights, threads)
         return map_out
 
@@ -298,7 +298,7 @@ class _ProjectionistBase:
             comps = self._guess_comps(shape[1:])
         projeng = self.get_ProjEng(comps)
         q_native = self._cache_q_fp_to_native(assembly.Q)
-        map_out = projeng.to_weight_map(output, q_native, assembly.fplane.coeffs(),
+        map_out = projeng.to_weight_map(output, q_native, assembly.fplane.quats,
             assembly.fplane.resps, det_weights, threads)
         return map_out
 
@@ -318,7 +318,7 @@ class _ProjectionistBase:
             comps = self._guess_comps(self._get_map_shape(src_map))
         projeng = self.get_ProjEng(comps)
         q_native = self._cache_q_fp_to_native(assembly.Q)
-        signal_out = projeng.from_map(src_map, q_native, assembly.fplane.coeffs(),
+        signal_out = projeng.from_map(src_map, q_native, assembly.fplane.quats,
             assembly.fplane.resps, signal)
         return signal_out
 
@@ -362,7 +362,7 @@ class _ProjectionistBase:
         if method == 'simple':
             projeng = self.get_ProjEng('T')
             q_native = self._cache_q_fp_to_native(assembly.Q)
-            omp_ivals = projeng.pixel_ranges(q_native, assembly.fplane.coeffs(), None, n_threads)
+            omp_ivals = projeng.pixel_ranges(q_native, assembly.fplane.quats, None, n_threads)
             return wrap_ivals(omp_ivals)
 
         elif method == 'domdir':
@@ -402,7 +402,7 @@ class _ProjectionistBase:
         projeng = self.get_ProjEng('T')
         q_native = self._cache_q_fp_to_native(assembly.Q)
         n_threads = mapthreads.get_num_threads(n_threads)
-        omp_ivals = projeng.pixel_ranges(q_native, assembly.fplane.coeffs(), tmap, n_threads)
+        omp_ivals = projeng.pixel_ranges(q_native, assembly.fplane.quats, tmap, n_threads)
         return wrap_ivals(omp_ivals)
 
     def get_active_tiles(self, assembly, assign=False):
@@ -441,7 +441,7 @@ class _ProjectionistBase:
         projeng = self.get_ProjEng('T')
         q_native = self._cache_q_fp_to_native(assembly.Q)
         # This returns a G3VectorInt of length n_tiles giving count of hits per tile.
-        hits = np.array(projeng.tile_hits(q_native, assembly.fplane.coeffs()))
+        hits = np.array(projeng.tile_hits(q_native, assembly.fplane.quats))
         tiles = np.nonzero(hits)[0]
         hits = hits[tiles]
         if assign is True:
@@ -460,7 +460,7 @@ class _ProjectionistBase:
             #     print(f"Warning: Threads poorly balanced. Max/mean hits = {max_ratio}")
 
             # Now paint them into Ranges.
-            R = projeng.tile_ranges(q_native, assembly.fplane.coeffs(), group_tiles)
+            R = projeng.tile_ranges(q_native, assembly.fplane.quats, group_tiles)
             R = wrap_ivals(R)
             return {
                 'active_tiles': list(tiles),
@@ -795,7 +795,7 @@ class ProjectionistHealpix(_ProjectionistBase):
             q_native = self._cache_q_fp_to_native(assembly.Q)
         else:
             q_native = assembly.Q
-        return projeng.coords(q_native, assembly.fplane.coeffs(), output)
+        return projeng.coords(q_native, assembly.fplane.quats, output)
 
     def from_map(self, src_map, assembly, signal=None, comps=None):
         """De-project from a map, returning a Signal-like object.

--- a/python/proj/wcs.py
+++ b/python/proj/wcs.py
@@ -183,7 +183,7 @@ class _ProjectionistBase:
         """
         projeng = self.get_ProjEng('TQU')
         q_native = self._cache_q_fp_to_native(assembly.Q)
-        return projeng.pixels(q_native, assembly.fplane.quats, None)
+        return projeng.pixels(q_native, assembly.fplane.coeffs(), None)
 
     def get_pointing_matrix(self, assembly):
         """Get the pointing matrix information, which is to say both the pixel
@@ -199,7 +199,7 @@ class _ProjectionistBase:
         """
         projeng = self.get_ProjEng('TQU')
         q_native = self._cache_q_fp_to_native(assembly.Q)
-        return projeng.pointing_matrix(q_native, assembly.fplane.quats, assembly.fplane.resps, None, None)
+        return projeng.pointing_matrix(q_native, assembly.fplane.coeffs(), assembly.fplane.resps, None, None)
 
     def get_coords(self, assembly, use_native=False, output=None):
         """Get the spherical coordinates for the provided pointing Assembly.
@@ -225,7 +225,7 @@ class _ProjectionistBase:
             q_native = self._cache_q_fp_to_native(assembly.Q)
         else:
             q_native = assembly.Q
-        return projeng.coords(q_native, assembly.fplane.quats, output)
+        return projeng.coords(q_native, assembly.fplane.coeffs(), output)
 
     def get_planar(self, assembly, output=None):
         """Get projection plane coordinates for all detectors at all times.
@@ -240,7 +240,7 @@ class _ProjectionistBase:
         """
         q_native = self._cache_q_fp_to_native(assembly.Q)
         projeng = self.get_ProjEng('TQU')
-        return projeng.coords(q_native, assembly.fplane.quats, output)
+        return projeng.coords(q_native, assembly.fplane.coeffs(), output)
 
     def zeros(self, super_shape):
         """Return a map, filled with zeros, with shape (super_shape,) +
@@ -272,7 +272,7 @@ class _ProjectionistBase:
             comps = self._guess_comps(self._get_map_shape(output))
         projeng = self.get_ProjEng(comps)
         q_native = self._cache_q_fp_to_native(assembly.Q)
-        map_out = projeng.to_map(output, q_native, assembly.fplane.quats,
+        map_out = projeng.to_map(output, q_native, assembly.fplane.coeffs(),
             assembly.fplane.resps, signal, det_weights, threads)
         return map_out
 
@@ -298,7 +298,7 @@ class _ProjectionistBase:
             comps = self._guess_comps(shape[1:])
         projeng = self.get_ProjEng(comps)
         q_native = self._cache_q_fp_to_native(assembly.Q)
-        map_out = projeng.to_weight_map(output, q_native, assembly.fplane.quats,
+        map_out = projeng.to_weight_map(output, q_native, assembly.fplane.coeffs(),
             assembly.fplane.resps, det_weights, threads)
         return map_out
 
@@ -318,7 +318,7 @@ class _ProjectionistBase:
             comps = self._guess_comps(self._get_map_shape(src_map))
         projeng = self.get_ProjEng(comps)
         q_native = self._cache_q_fp_to_native(assembly.Q)
-        signal_out = projeng.from_map(src_map, q_native, assembly.fplane.quats,
+        signal_out = projeng.from_map(src_map, q_native, assembly.fplane.coeffs(),
             assembly.fplane.resps, signal)
         return signal_out
 
@@ -362,7 +362,7 @@ class _ProjectionistBase:
         if method == 'simple':
             projeng = self.get_ProjEng('T')
             q_native = self._cache_q_fp_to_native(assembly.Q)
-            omp_ivals = projeng.pixel_ranges(q_native, assembly.fplane.quats, None, n_threads)
+            omp_ivals = projeng.pixel_ranges(q_native, assembly.fplane.coeffs(), None, n_threads)
             return wrap_ivals(omp_ivals)
 
         elif method == 'domdir':
@@ -402,7 +402,7 @@ class _ProjectionistBase:
         projeng = self.get_ProjEng('T')
         q_native = self._cache_q_fp_to_native(assembly.Q)
         n_threads = mapthreads.get_num_threads(n_threads)
-        omp_ivals = projeng.pixel_ranges(q_native, assembly.fplane.quats, tmap, n_threads)
+        omp_ivals = projeng.pixel_ranges(q_native, assembly.fplane.coeffs(), tmap, n_threads)
         return wrap_ivals(omp_ivals)
 
     def get_active_tiles(self, assembly, assign=False):
@@ -441,7 +441,7 @@ class _ProjectionistBase:
         projeng = self.get_ProjEng('T')
         q_native = self._cache_q_fp_to_native(assembly.Q)
         # This returns a G3VectorInt of length n_tiles giving count of hits per tile.
-        hits = np.array(projeng.tile_hits(q_native, assembly.fplane.quats))
+        hits = np.array(projeng.tile_hits(q_native, assembly.fplane.coeffs()))
         tiles = np.nonzero(hits)[0]
         hits = hits[tiles]
         if assign is True:
@@ -460,7 +460,7 @@ class _ProjectionistBase:
             #     print(f"Warning: Threads poorly balanced. Max/mean hits = {max_ratio}")
 
             # Now paint them into Ranges.
-            R = projeng.tile_ranges(q_native, assembly.fplane.quats, group_tiles)
+            R = projeng.tile_ranges(q_native, assembly.fplane.coeffs(), group_tiles)
             R = wrap_ivals(R)
             return {
                 'active_tiles': list(tiles),
@@ -795,7 +795,7 @@ class ProjectionistHealpix(_ProjectionistBase):
             q_native = self._cache_q_fp_to_native(assembly.Q)
         else:
             q_native = assembly.Q
-        return projeng.coords(q_native, assembly.dets, output)
+        return projeng.coords(q_native, assembly.fplane.coeffs(), output)
 
     def from_map(self, src_map, assembly, signal=None, comps=None):
         """De-project from a map, returning a Signal-like object.

--- a/python/proj/wcs.py
+++ b/python/proj/wcs.py
@@ -373,7 +373,7 @@ class Projectionist:
         """
         projeng = self.get_ProjEng('TQU')
         q_native = self._cache_q_fp_to_native(assembly.Q)
-        return projeng.pointing_matrix(q_native, assembly.dets, None, None)
+        return projeng.pointing_matrix(q_native, assembly.fplane.quats, assembly.fplane.resps, None, None)
 
     def get_coords(self, assembly, use_native=False, output=None):
         """Get the spherical coordinates for the provided pointing Assembly.
@@ -446,8 +446,8 @@ class Projectionist:
             comps = self._guess_comps(output.shape)
         projeng = self.get_ProjEng(comps)
         q_native = self._cache_q_fp_to_native(assembly.Q)
-        map_out = projeng.to_map(
-            output, q_native, assembly.dets, signal, det_weights, threads)
+        map_out = projeng.to_map(output, q_native, assembly.fplane.quats,
+            assembly.fplane.resps, signal, det_weights, threads)
         return map_out
 
     def to_weights(self, assembly, output=None, det_weights=None,
@@ -471,8 +471,8 @@ class Projectionist:
             comps = self._guess_comps(output.shape[1:])
         projeng = self.get_ProjEng(comps)
         q_native = self._cache_q_fp_to_native(assembly.Q)
-        map_out = projeng.to_weight_map(
-            output, q_native, assembly.dets, det_weights, threads)
+        map_out = projeng.to_weight_map(output, q_native, assembly.fplane.quats,
+            assembly.fplane.resps, det_weights, threads)
         return map_out
 
     def from_map(self, src_map, assembly, signal=None, comps=None):
@@ -494,8 +494,8 @@ class Projectionist:
             comps = self._guess_comps(src_map.shape)
         projeng = self.get_ProjEng(comps)
         q_native = self._cache_q_fp_to_native(assembly.Q)
-        signal_out = projeng.from_map(
-            src_map, q_native, assembly.dets, signal)
+        signal_out = projeng.from_map(src_map, q_native, assembly.fplane.quats,
+            assembly.fplane.resps, signal)
         return signal_out
 
     def assign_threads(self, assembly, method='domdir', n_threads=None):

--- a/src/Projection.cxx
+++ b/src/Projection.cxx
@@ -22,6 +22,7 @@ using namespace std;
 #include "exceptions.h"
 #include "so_linterp.h"
 
+#include <stdio.h>
 
 // TRIG_TABLE_SIZE
 //
@@ -855,35 +856,47 @@ inline int Pixelizor2_Flat<Tiled, Bilinear>::GetPixels(int i_det, int i_time, co
     return iout;
 }
 
+// This struct is used for representing the total intensity and polarization
+// response of a single detector. Originally this was just a length-2 array,
+// but those can't easily be returned from functions. If I could ensure
+// the buffer had stride-1 in the last dimension, then one could simply pass
+// in the address to the first element for a detector, BufferWrapper doesn't make
+// that straightforward, so I think this approach is best.
+struct Response { FSIGNAL T, P; };
+Response get_response(BufferWrapper<FSIGNAL> & buf, int i_det) {
+    Response r = {*buf.ptr_2d(i_det,0), *buf.ptr_2d(i_det,1)};
+    return r;
+}
+
 template <typename SpinSys>
 static inline
-void spin_proj_factors(const double* coords, FSIGNAL *projfacs);
+void spin_proj_factors(const double* coords, const Response & response, FSIGNAL *projfacs);
 
 template <>
-inline void spin_proj_factors<SpinT>(const double* coords, FSIGNAL *projfacs)
+inline void spin_proj_factors<SpinT>(const double* coords, const Response & response, FSIGNAL *projfacs)
 {
-    projfacs[0] = 1.;
+    projfacs[0] = response.T;
 }
 
 template <>
 inline
-void spin_proj_factors<SpinQU>(const double* coords, FSIGNAL *projfacs)
+void spin_proj_factors<SpinQU>(const double* coords, const Response & response, FSIGNAL *projfacs)
 {
     const double c = coords[2];
     const double s = coords[3];
-    projfacs[0] = c*c - s*s;
-    projfacs[1] = 2*c*s;
+    projfacs[0] = response.P*(c*c - s*s);
+    projfacs[1] = response.P*(2*c*s);
 }
 
 template <>
 inline
-void spin_proj_factors<SpinTQU>(const double* coords, FSIGNAL *projfacs)
+void spin_proj_factors<SpinTQU>(const double* coords, const Response & response, FSIGNAL *projfacs)
 {
      const double c = coords[2];
      const double s = coords[3];
-     projfacs[0] = 1.;
-     projfacs[1] = c*c - s*s;
-     projfacs[2] = 2*c*s;
+     projfacs[0] = response.T;
+     projfacs[1] = response.P*(c*c - s*s);
+     projfacs[2] = response.P*(2*c*s);
 }
 
 
@@ -1068,7 +1081,7 @@ bp::object ProjectionEngine<C,P,S>::pixels(
 // sample
 template<typename C, typename P, typename S>
 bp::object ProjectionEngine<C,P,S>::pointing_matrix(
-    bp::object pbore, bp::object pofs, bp::object pixel, bp::object proj)
+    bp::object pbore, bp::object pofs, bp::object response, bp::object pixel, bp::object proj)
 {
     auto _none = bp::object();
 
@@ -1081,9 +1094,10 @@ bp::object ProjectionEngine<C,P,S>::pointing_matrix(
 
     auto pixel_buf_man = SignalSpace<int32_t>(
         pixel, "pixel", NPY_INT32, n_det, n_time, P::index_count);
-
     auto proj_buf_man = SignalSpace<FSIGNAL>(
         proj, "proj", FSIGNAL_NPY_TYPE, n_det, n_time, S::comp_count);
+    auto _response = BufferWrapper<FSIGNAL>(
+         "response", response, false, vector<int>{n_det,2});
 
 #pragma omp parallel for
     for (int i_det = 0; i_det < n_det; ++i_det) {
@@ -1093,12 +1107,13 @@ bp::object ProjectionEngine<C,P,S>::pointing_matrix(
         FSIGNAL* const proj_buf = proj_buf_man.data_ptr[i_det];
         const int step = pixel_buf_man.steps[0];
         int pixel_offset[P::index_count] = {-1};
+        Response resp = get_response(_response, i_det);
         for (int i_time = 0; i_time < n_time; ++i_time) {
             double coords[4];
             FSIGNAL pf[S::comp_count];
             pointer.GetCoords(i_det, i_time, (double*)dofs, (double*)coords);
             _pixelizor.GetPixel(i_det, i_time, (double*)coords, pixel_offset);
-            spin_proj_factors<S>(coords, pf);
+            spin_proj_factors<S>(coords, resp, pf);
 
             for (int i_dim = 0; i_dim < P::index_count; i_dim++)
                 pix_buf[i_time * pixel_buf_man.steps[0] +
@@ -1403,7 +1418,7 @@ bp::object ProjectionEngine<C,P,S>::zeros(bp::object shape)
 
 template<typename C, typename P, typename S>
 bp::object ProjectionEngine<C,P,S>::from_map(
-    bp::object map, bp::object pbore, bp::object pofs, bp::object signal)
+    bp::object map, bp::object pbore, bp::object pofs, bp::object response, bp::object signal)
 {
     auto _none = bp::object();
 
@@ -1419,6 +1434,8 @@ bp::object ProjectionEngine<C,P,S>::from_map(
     // Get pointers to the signal and (optional) per-det weights.
     auto _signalspace = SignalSpace<FSIGNAL>(
             signal, "signal", FSIGNAL_NPY_TYPE, n_det, n_time);
+    auto _response = BufferWrapper<FSIGNAL>(
+         "response", response, false, vector<int>{n_det,2});
 
     #pragma omp parallel for
     for (int i_det = 0; i_det < n_det; ++i_det) {
@@ -1427,10 +1444,11 @@ bp::object ProjectionEngine<C,P,S>::from_map(
         int pixinds[P::interp_count][P::index_count] = {-1};
         FSIGNAL pixweights[P::interp_count];
         FSIGNAL pf[S::comp_count];
+        Response resp = get_response(_response, i_det);
         for (int i_time = 0; i_time < n_time; ++i_time) {
             double coords[4];
             pointer.GetCoords(i_det, i_time, (double*)dofs, (double*)coords);
-            spin_proj_factors<S>(coords, pf);
+            spin_proj_factors<S>(coords, resp, pf);
             FSIGNAL *sig = (_signalspace.data_ptr[i_det] + _signalspace.steps[0]*i_time);
             int n_point = _pixelizor.GetPixels(i_det, i_time, coords, pixinds, pixweights);
             for(int i_point = 0; i_point < n_point; ++i_point)
@@ -1445,6 +1463,7 @@ bp::object ProjectionEngine<C,P,S>::from_map(
 template<typename C, typename P, typename S>
 static
 void to_map_single_thread(Pointer<C> &pointer,
+                          BufferWrapper<FSIGNAL> & _response,
                           P &_pixelizor,
                           const vector<RangesInt32> & ivals,
                           BufferWrapper<FSIGNAL> &_det_weights,
@@ -1462,13 +1481,14 @@ void to_map_single_thread(Pointer<C> &pointer,
         double coords[4];
         FSIGNAL pf[S::comp_count];
         pointer.InitPerDet(i_det, dofs);
+        Response resp = get_response(_response, i_det);
         // Pointing matrix interpolation stuff
         int pixinds[P::interp_count][P::index_count] = {-1};
         FSIGNAL pixweights[P::interp_count] = {0};
         for (auto const &rng: ivals[i_det].segments) {
             for (int i_time = rng.first; i_time < rng.second; ++i_time) {
                 pointer.GetCoords(i_det, i_time, (double*)dofs, (double*)coords);
-                spin_proj_factors<S>(coords, pf);
+                spin_proj_factors<S>(coords, resp, pf);
                 const FSIGNAL sig = _signalspace->data_ptr[i_det][_signalspace->steps[0]*i_time];
                 // In interpolated mapmaking like bilinear mampamking, each sample hits multipe
                 // pixels, each with its own weight.
@@ -1484,6 +1504,7 @@ void to_map_single_thread(Pointer<C> &pointer,
 template<typename C, typename P, typename S>
 static
 void to_weight_map_single_thread(Pointer<C> &pointer,
+                                 BufferWrapper<FSIGNAL> & _response,
                                  P &_pixelizor,
                                  vector<RangesInt32> ivals,
                                  BufferWrapper<FSIGNAL> &_det_weights)
@@ -1500,12 +1521,13 @@ void to_weight_map_single_thread(Pointer<C> &pointer,
         double coords[4];
         FSIGNAL pf[S::comp_count];
         pointer.InitPerDet(i_det, dofs);
+        Response resp = get_response(_response, i_det);
         int pixinds[P::interp_count][P::index_count] = {-1};
         FSIGNAL pixweights[P::interp_count] = {0};
         for (auto const &rng: ivals[i_det].segments) {
             for (int i_time = rng.first; i_time < rng.second; ++i_time) {
                 pointer.GetCoords(i_det, i_time, (double*)dofs, (double*)coords);
-                spin_proj_factors<S>(coords, pf);
+                spin_proj_factors<S>(coords, resp, pf);
 
                 int n_point = _pixelizor.GetPixels(i_det, i_time, coords, pixinds, pixweights);
                 // Is this enough? Do we need a double loop over i_point?
@@ -1592,8 +1614,8 @@ vector<vector<vector<RangesInt32>>> derive_ranges(
 
 template<typename C, typename P, typename S>
 bp::object ProjectionEngine<C,P,S>::to_map(
-    bp::object map, bp::object pbore, bp::object pofs, bp::object signal, bp::object det_weights,
-    bp::object thread_intervals)
+    bp::object map, bp::object pbore, bp::object pofs, bp::object response,
+    bp::object signal, bp::object det_weights, bp::object thread_intervals)
 {
     //Initialize it / check inputs.
     auto pointer = Pointer<C>();
@@ -1613,6 +1635,8 @@ bp::object ProjectionEngine<C,P,S>::to_map(
             signal, "signal", FSIGNAL_NPY_TYPE, n_det, n_time);
     auto _det_weights = BufferWrapper<FSIGNAL>(
          "det_weights", det_weights, true, vector<int>{n_det});
+    auto _response = BufferWrapper<FSIGNAL>(
+         "response", response, false, vector<int>{n_det,2});
 
     // For multi-threading, the principle here is that we loop serially
     // over bunches, and then inside each block all threads loop over
@@ -1627,15 +1651,15 @@ bp::object ProjectionEngine<C,P,S>::to_map(
         // or if ivals.size() == 1
         #pragma omp parallel for
         for (int i_thread = 0; i_thread < ivals.size(); i_thread++)
-            to_map_single_thread<C,P,S>(pointer, _pixelizor, ivals[i_thread], _det_weights, &_signalspace);
+            to_map_single_thread<C,P,S>(pointer, _response, _pixelizor, ivals[i_thread], _det_weights, &_signalspace);
     }
     return map;
 }
 
 template<typename C, typename P, typename S>
 bp::object ProjectionEngine<C,P,S>::to_weight_map(
-    bp::object map, bp::object pbore, bp::object pofs, bp::object det_weights,
-    bp::object thread_intervals)
+    bp::object map, bp::object pbore, bp::object pofs, bp::object response,
+    bp::object det_weights, bp::object thread_intervals)
 {
     auto _none = bp::object();
 
@@ -1655,6 +1679,8 @@ bp::object ProjectionEngine<C,P,S>::to_weight_map(
     // Get pointer to (optional) per-det weights.
     auto _det_weights = BufferWrapper<FSIGNAL>(
          "det_weights", det_weights, true, vector<int>{n_det});
+    auto _response = BufferWrapper<FSIGNAL>(
+         "response", response, false, vector<int>{n_det,2});
 
     // For multi-threading, the principle here is that we loop serially
     // over bunches, and then inside each block all threads loop over
@@ -1669,7 +1695,7 @@ bp::object ProjectionEngine<C,P,S>::to_weight_map(
         // or if ivals.size() == 1
         #pragma omp parallel for
         for (int i_thread = 0; i_thread < ivals.size(); i_thread++)
-            to_weight_map_single_thread<C,P,S>(pointer, _pixelizor, ivals[i_thread], _det_weights);
+            to_weight_map_single_thread<C,P,S>(pointer, _response, _pixelizor, ivals[i_thread], _det_weights);
     }
     return map;
 }

--- a/src/Projection.cxx
+++ b/src/Projection.cxx
@@ -121,6 +121,58 @@ inline bool isNone(const bp::object &pyo)
 // shape [1][ndet][nrange]. More complicated schemes could be used, but this
 // seems to work well enough.
 
+// Arbitrary detector response support
+// -----------------------------------
+// Useful to support detectors with polarization response < 1. Also occasionally
+// useful with detectors with 0 total intensity response. Currently the detector
+// response is only encoded indirectly through the detector angle on the sky, part
+// of the per-detector quaternion. Hard to cram the rest of the response into this,
+// so must be handled with a new argument.
+//
+// spin_proj_factors: cos(2psi),sin(2psi) → detector on-sky TQU response
+//  psi is here the projected detector angle, which is computed by Pointer::GetCoords
+//  It makes sense for this to deal with angles since it's the result of a quaternion
+//  pointing calculation.
+//
+// Probably best to leave GetCoords alone, and instead augment spin_proj_factors with
+// T and P support. For example:
+//
+// void spin_proj_factors<SpinTQU>(const double * coords, const double * response, FSIGNAL * projfacs) {
+//     const double c = coords[2];
+//     const double s = coords[3];
+//     projfacs[0] = response[0];
+//     projfacs[1] = response[1]*(c*c - s*s);
+//     projfacs[2] = response[1]*(2*c*s);
+// }
+//
+// None of the arguments to to_map and its relatives are a natural place to put response.
+// It could be shoehorned into pofs by making it length 6, but the first four components
+// would hold quaternion coefficients making it unnatural to have the last 2 be responses.
+// It's probably better to modify these functions to take an additional response argument,
+// e.g.
+//
+// template<typename C, typename P, typename S>
+//     bp::object ProjectionEngine<C,P,S>::to_map(
+//     bp::object map, bp::object pbore, bp::object pofs, bp::object det_response,
+//     bp::object signal, bp::object det_weights, bp::object thread_intervals)
+//
+// where these would then be extracted using
+//
+//  auto _det_response = BufferWrapper<FSIGNAL>("det_response", det_response, false, vector<int>{n_det,2});
+//
+// Could make it optional, but easier to handle this on the python side.
+//
+// List of functions needing modification:
+// * ProjectionEngine<C,P,S>::pointing_matrix
+// * ProjectionEngine<C,P,S>::from_map
+// * ProjectionEngine<C,P,S>::to_map
+// * ProjectionEngine<C,P,S>::to_weight_map
+// * to_map_single_thread
+// * to_weight_map_single_thread
+//
+// * python/wcs.py/Projectionist
+// * python/mapthreads.py/get_threads_domdir
+
 // State the template<CoordSys> options
 class ProjQuat;
 class ProjFlat;

--- a/test/test_proj_astro.py
+++ b/test/test_proj_astro.py
@@ -195,12 +195,10 @@ class TestProjAstrometry(unittest.TestCase):
 
     def test_focalplane(self):
         # Focal plane
-        names = ['a', 'b', 'c']
         xi  = np.array([1., 0., 0.]) * DEG
         eta = np.array([0., 0., 1.]) * DEG
         gamma = np.array([45, 0, -45]) * DEG
-        fp = so3g.proj.FocalPlane.from_xieta(names, xi, eta, gamma)
-        print(fp)
+        fp = so3g.proj.FocalPlane.from_xieta(xi, eta, gamma)
 
         # Make a CelestialSightLine with some known equatorial pointing.
         r = so3g.proj.quat.rotation_lonlat(35*DEG, 80*DEG, 15*DEG)
@@ -213,13 +211,14 @@ class TestProjAstrometry(unittest.TestCase):
         coords = csl.coords(fp)
 
         # Compare to a more direct computation, done here.
-        for k, roffset in fp.items():
-            print('Check detector %s:' % k)
+        for i, (roffset, resp) in enumerate(fp.items()):
+            print('Check detector %d:' % i)
             r1 = r * roffset
+            print("AAA", type(r1), r1)
             lon0, lat0, gamma0 = so3g.proj.quat.decompose_lonlat(r1)
             print('  - inline computation: ',
                   lon0 / DEG, lat0 / DEG, gamma0 / DEG)
-            lon1, lat1, cosg, sing = coords[k][0]
+            lon1, lat1, cosg, sing = coords[i][0]
             gamma1 = np.arctan2(sing, cosg)
             print('  - proj computation: ',
                   lon1 / DEG, lat1 / DEG, gamma1 / DEG)

--- a/test/test_proj_eng.py
+++ b/test/test_proj_eng.py
@@ -35,7 +35,7 @@ def get_scan():
 def get_basics(clipped=True):
     t, az, el = get_scan()
     csl = proj.CelestialSightLine.az_el(t, az, el, weather='vacuum', site='so')
-    fp = proj.FocalPlane.from_xieta(['a', 'b'], [0., .1*DEG], [0, .1*DEG])
+    fp = proj.FocalPlane.from_xieta([0., .1*DEG], [0, .1*DEG])
     asm = proj.Assembly.attach(csl, fp)
 
     # And a map ... of where?
@@ -73,8 +73,7 @@ class TestProjEng(unittest.TestCase):
                      det_weights=np.array([0., 0.], dtype='float32'))[0]
         assert(np.all(m==0))
 
-        # Raise if pointing invalid.
-        asm.dets[1,2] = np.nan
+        asm.fplane.quats[1,2] = np.nan
         with self.assertRaises(ValueError):
            p.to_map(sig, asm, comps='T')
         with self.assertRaises(ValueError):

--- a/test/test_proj_eng.py
+++ b/test/test_proj_eng.py
@@ -73,7 +73,9 @@ class TestProjEng(unittest.TestCase):
                      det_weights=np.array([0., 0.], dtype='float32'))[0]
         assert(np.all(m==0))
 
-        asm.fplane.quats[1,2] = np.nan
+        # Can't assign to quat fields, so do
+        # it this way instead
+        asm.fplane.quats[1] = asm.fplane.quats[1]*np.nan
         with self.assertRaises(ValueError):
            p.to_map(sig, asm, comps='T')
         with self.assertRaises(ValueError):

--- a/test/test_proj_eng_hp.py
+++ b/test/test_proj_eng_hp.py
@@ -32,7 +32,7 @@ class TestProjEngHP(unittest.TestCase):
     """Test ProjectionistHealpix
        Based on TestProjEng
     """
-    
+
     def test_00_basic(self):
         scan, asm = get_basics()
         nside = 128
@@ -51,8 +51,9 @@ class TestProjEngHP(unittest.TestCase):
                      det_weights=np.array([0., 0.], dtype='float32'))[0]
         assert(np.all(m==0))
 
-        # Raise if pointing invalid.
-        asm.fplane.quats[1,2] = np.nan
+        # Can't assign to quat fields, so do
+        # it this way instead
+        asm.fplane.quats[1] = asm.fplane.quats[1]*np.nan
         with self.assertRaises(ValueError):
            p.to_map(sig, asm, comps='T')
         with self.assertRaises(ValueError):
@@ -74,7 +75,7 @@ class TestProjEngHP(unittest.TestCase):
                 assert(np.any(w2))
             # Identify active subtiles?
             print(p.active_tiles)
-        
+
     def test_20_threads(self):
         for (tiled, interpol, method) in itertools.product(
                 [False, True],
@@ -88,7 +89,7 @@ class TestProjEngHP(unittest.TestCase):
                 nside_tile = 8
             else:
                 nside_tile = None
-                
+
             p = proj.ProjectionistHealpix.for_healpix(nside, nside_tile, interpol=interpol)
             sig = np.ones((2, len(scan[0])), 'float32')
             n_threads = 3

--- a/test/test_proj_eng_hp.py
+++ b/test/test_proj_eng_hp.py
@@ -23,7 +23,7 @@ def get_scan():
 def get_basics():
     t, az, el = get_scan()
     csl = proj.CelestialSightLine.az_el(t, az, el, weather='vacuum', site='so')
-    fp = proj.FocalPlane.from_xieta(['a', 'b'], [0., .1*DEG], [0, .1*DEG])
+    fp = proj.FocalPlane.from_xieta([0., .1*DEG], [0, .1*DEG])
     asm = proj.Assembly.attach(csl, fp)
     return ((t, az, el), asm)
 
@@ -52,7 +52,7 @@ class TestProjEngHP(unittest.TestCase):
         assert(np.all(m==0))
 
         # Raise if pointing invalid.
-        asm.dets[1,2] = np.nan
+        asm.fplane.quats[1,2] = np.nan
         with self.assertRaises(ValueError):
            p.to_map(sig, asm, comps='T')
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Edit: No longer breaks backwards compatibility - see jan 10 comment.

The pointing matrix in so3g has had a hardcoded polarization efficiency of 100%. This pull request updates it to support arbitrary T and P responses per detector. This was needed to be able to represent demodulated timestreams as virtual detectors, which will be a separate pull request for sotodlib later. The virtual detector approach to demodulation mapmaking has the advantage that none of the rest of the code needs to know about the demodulation, only the demodulation function itself.

This breaks backwards compatibility in the interface of the FocalPlane object. It used to be an OrderedDict of `[name, q]` where q is an entry in a `G3VectorQuat`, but it is now a class with the members `.quats`, which is an [ndet,4] array of quaternion coefficients, and `.resps`, which is an `[ndet,2]` array of T and P responses. This means that FocalPlane no longer supports named detectors. This simplifies `Assembly`, which now just contains a FocalPlane instance.

This incompatibility will require corresponding changes in sotodlib. Do we have to go through a slow dance of add compatibility layer in sotodlib, wait for a few weeks, update so3g, then remove compatibility layer in sotodlib, again? I hope not. What do you think?