### PR TITLE
Add tunable buffer size for spt3g filtering_istream

### DIFF
--- a/wheels/install_deps_linux.sh
+++ b/wheels/install_deps_linux.sh
@@ -110,6 +110,26 @@ tar xjf ${boost_pkg} \
     ${pyincl} cxxflags="${CXXFLAGS}" variant=release threading=multi link=shared runtime-link=shared install \
     && popd >/dev/null 2>&1
 
+# Build GSL
+
+gsl_version=2.8
+gsl_dir=gsl-${gsl_version}
+gsl_pkg=${gsl_dir}.tar.gz
+
+if [ ! -e ${gsl_pkg} ]; then
+    echo "Fetching GSL..."
+    curl -SL https://ftp.gnu.org/gnu/gsl/gsl-${gsl_version}.tar.gz -o ${gsl_pkg}
+fi
+
+echo "Building GSL..."
+
+rm -rf ${gsl_dir}
+tar xzf ${gsl_pkg} \
+    && pushd ${gsl_dir} >/dev/null 2>&1 \
+    && CC="${CC}" CFLAGS="-O3 -fPIC" ./configure --prefix="${PREFIX}" \
+    && make -j ${MAKEJ} install \
+    && popd >/dev/null 2>&1
+
 # Astropy caching...
 
 echo "Attempting to trigger astropy IERS download..."

--- a/wheels/install_deps_linux.sh
+++ b/wheels/install_deps_linux.sh
@@ -126,8 +126,11 @@ echo "Building GSL..."
 rm -rf ${gsl_dir}
 tar xzf ${gsl_pkg} \
     && pushd ${gsl_dir} >/dev/null 2>&1 \
-    && CC="${CC}" CFLAGS="-O3 -fPIC" ./configure --prefix="${PREFIX}" \
-    && make -j ${MAKEJ} install \
+    && mkdir -p build \
+    && pushd build >/dev/null 2>&1 \
+    && CC="${CC}" CFLAGS="-O3 -fPIC" ../configure --prefix="${PREFIX}" \
+    && make -j ${MAKEJ} \
+    && make install \
     && popd >/dev/null 2>&1
 
 # Astropy caching...

--- a/wheels/install_deps_osx.sh
+++ b/wheels/install_deps_osx.sh
@@ -134,6 +134,26 @@ tar xjf ${boost_pkg} \
     variant=release threading=multi link=shared runtime-link=shared install \
     && popd >/dev/null 2>&1
 
+# Build GSL
+
+gsl_version=2.8
+gsl_dir=gsl-${gsl_version}
+gsl_pkg=${gsl_dir}.tar.gz
+
+if [ ! -e ${gsl_pkg} ]; then
+    echo "Fetching GSL..."
+    curl -SL https://ftp.gnu.org/gnu/gsl/gsl-${gsl_version}.tar.gz -o ${gsl_pkg}
+fi
+
+echo "Building GSL..."
+
+rm -rf ${gsl_dir}
+tar xzf ${gsl_pkg} \
+    && pushd ${gsl_dir} >/dev/null 2>&1 \
+    && CC="${CC}" CFLAGS="-O3 -fPIC" ./configure --prefix="${PREFIX}" \
+    && make -j ${MAKEJ} install \
+    && popd >/dev/null 2>&1
+
 # Astropy caching...
 
 echo "Attempting to trigger astropy IERS download..."

--- a/wheels/install_deps_osx.sh
+++ b/wheels/install_deps_osx.sh
@@ -150,8 +150,11 @@ echo "Building GSL..."
 rm -rf ${gsl_dir}
 tar xzf ${gsl_pkg} \
     && pushd ${gsl_dir} >/dev/null 2>&1 \
-    && CC="${CC}" CFLAGS="-O3 -fPIC" ./configure --prefix="${PREFIX}" \
-    && make -j ${MAKEJ} install \
+    && mkdir -p build \
+    && pushd build >/dev/null 2>&1 \
+    && CC="${CC}" CFLAGS="-O3 -fPIC" ../configure --prefix="${PREFIX}" \
+    && make -j ${MAKEJ} \
+    && make install \
     && popd >/dev/null 2>&1
 
 # Astropy caching...

--- a/wheels/spt3g.patch
+++ b/wheels/spt3g.patch
@@ -1,6 +1,6 @@
-diff -urN spt3g_software_orig/cmake/Spt3gBoostPython.cmake spt3g_software/cmake/Spt3gBoostPython.cmake
+diff -urN spt3g_software_orig/cmake/Spt3gBoostPython.cmake spt3g_software_export/cmake/Spt3gBoostPython.cmake
 --- spt3g_software_orig/cmake/Spt3gBoostPython.cmake	2024-08-22 10:25:14.077183587 -0700
-+++ spt3g_software/cmake/Spt3gBoostPython.cmake	2024-08-22 10:27:10.956608507 -0700
++++ spt3g_software_export/cmake/Spt3gBoostPython.cmake	2024-12-11 12:24:37.355444860 -0800
 @@ -1,7 +1,7 @@
  # Locate Python
  
@@ -10,9 +10,9 @@ diff -urN spt3g_software_orig/cmake/Spt3gBoostPython.cmake spt3g_software/cmake/
  else()
  	find_package(PythonInterp)
  	find_package(PythonLibs ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
-diff -urN spt3g_software_orig/CMakeLists.txt spt3g_software/CMakeLists.txt
+diff -urN spt3g_software_orig/CMakeLists.txt spt3g_software_export/CMakeLists.txt
 --- spt3g_software_orig/CMakeLists.txt	2024-08-22 10:24:59.301256298 -0700
-+++ spt3g_software/CMakeLists.txt	2024-08-23 12:33:59.073140890 -0700
++++ spt3g_software_export/CMakeLists.txt	2024-12-11 12:24:37.364444816 -0800
 @@ -42,7 +42,7 @@
  
  # Raise errors on every warning by default
@@ -22,9 +22,9 @@ diff -urN spt3g_software_orig/CMakeLists.txt spt3g_software/CMakeLists.txt
  
  # Interface library for flags and library dependencies
  add_library(spt3g INTERFACE)
-diff -urN spt3g_software_orig/core/CMakeLists.txt spt3g_software/core/CMakeLists.txt
+diff -urN spt3g_software_orig/core/CMakeLists.txt spt3g_software_export/core/CMakeLists.txt
 --- spt3g_software_orig/core/CMakeLists.txt	2024-08-06 11:34:45.598647939 -0700
-+++ spt3g_software/core/CMakeLists.txt	2024-08-22 10:29:17.655985088 -0700
++++ spt3g_software_export/core/CMakeLists.txt	2024-12-11 12:24:37.364444816 -0800
 @@ -105,8 +105,8 @@
  add_spt3g_test(quaternions)
  add_spt3g_test(timesample)
@@ -39,12 +39,30 @@ diff -urN spt3g_software_orig/core/CMakeLists.txt spt3g_software/core/CMakeLists
 +#                         ${CMAKE_CURRENT_SOURCE_DIR}/tests/G3TimestreamTest.cxx
 +#                         ${CMAKE_CURRENT_SOURCE_DIR}/tests/G3TimestreamMapTest.cxx
 +#                       USE_PROJECTS core)
-diff -urN spt3g_software_orig/examples/CMakeLists.txt spt3g_software/examples/CMakeLists.txt
+diff -urN spt3g_software_orig/core/src/dataio.cxx spt3g_software_export/core/src/dataio.cxx
+--- spt3g_software_orig/core/src/dataio.cxx	2024-08-06 11:34:45.606647906 -0700
++++ spt3g_software_export/core/src/dataio.cxx	2024-12-11 12:24:45.732404214 -0800
+@@ -146,8 +146,14 @@
+ 		stream.push(fs);
+ 	} else {
+ 		// Simple file case
++		const char * bufcheck = getenv("SO3G_FILESYSTEM_BUFFER");
++		// Use 20MB default
++		size_t so3g_buffer_size = 20971520;
++		if (bufcheck != nullptr) {
++			so3g_buffer_size = (size_t)atol(bufcheck);
++		}
+ 		stream.push(boost::iostreams::file_source(path,
+-		    std::ios::binary));
++		    std::ios::binary), so3g_buffer_size);
+ 	}
+ 
+ 	return fd;
+diff -urN spt3g_software_orig/examples/CMakeLists.txt spt3g_software_export/examples/CMakeLists.txt
 --- spt3g_software_orig/examples/CMakeLists.txt	2024-08-06 11:34:45.610647890 -0700
-+++ spt3g_software/examples/CMakeLists.txt	2024-08-22 10:56:07.300059646 -0700
++++ spt3g_software_export/examples/CMakeLists.txt	2024-12-11 12:24:37.365444811 -0800
 @@ -1,2 +1,2 @@
 -add_executable(cppexample cppexample.cxx) 
 -target_link_libraries(cppexample core)
 +#add_executable(cppexample cppexample.cxx) 
 +#target_link_libraries(cppexample core)
-Binary files spt3g_software_orig/.git/index and spt3g_software/.git/index differ


### PR DESCRIPTION
This adds a small (and perhaps temporary) patch to specify the buffer size to the `filtering_istream` stack.  This is a quick update to fix slow data loading and #192 will be rebased after this is merged.  Also added GSL to the wheel build dependencies.

For testing on a compute node on perlmutter.nersc.gov, I used a single process and 8 threads.  I then loaded one wafer (ufm_mv12) of satp3 observation `obs_1714550584_satp3_1111111`.

I used the new `SO3G_FILESYSTEM_BUFFER` environment variable to try a variety of buffer sizes loading this same data from the CFS and scratch filesystems.  Note that the frame files in this case are each ~200MB, so the largest buffer size tested is actually larger than the frame files.  The smaller values of buffer size were essentially unusable on CFS.

Here is a plot of the times:
![spt3g_load](https://github.com/user-attachments/assets/ed9fef3b-e4da-43d8-9024-383da9e9041f)

Note that CFS access is faster from a login node than a compute node, and scratch access is faster from a compute node than a login node.  Here is the data in the plot:
```
Scratch Filesystem
-----------------------------------------------
Buffer Bytes        Time
0                    24.7
10                   6.71
100                  3.97
1000                 3.72
10000                3.6
100000               3.6     
1000000              3.6
10000000             3.6
20971520             3.7  (new default)  (13.8 on login)
100000000            3.8
1000000000          11.8

CFS Filesystem
-----------------------------------------------
Buffer Bytes        Time
0           
10          
100         
1000        
10000               523.0
100000              212.5
1000000              41.8
10000000             21.5
20971520             18.9  (new default)  (4.9 on login)
100000000            17.5
1000000000           24.8
```