### PR TITLE
Fix segfault in recent wheel builds

### DIFF
--- a/wheels/install_deps_linux.sh
+++ b/wheels/install_deps_linux.sh
@@ -215,6 +215,9 @@ tar xzf ${glog_pkg} \
     -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
     -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -DWITH_GFLAGS:BOOL=OFF \
+    -DWITH_GTEST:BOOL=OFF \
+    -DBUILD_SHARED_LIBS:BOOL=OFF \
     .. \
     && make -j ${MAKEJ} install \
     && popd >/dev/null 2>&1 \
@@ -249,7 +252,7 @@ tar xzf ${ceres_pkg} \
     -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
     -DBUILD_EXAMPLES=OFF \
     -DBUILD_BENCHMARKS=OFF \
-    -DBUILD_SHARED_LIBS=ON \
+    -DBUILD_SHARED_LIBS=OFF \
     -DBUILD_TESTING=OFF \
     -DGFLAGS=OFF \
     -DSUITESPARSE=OFF \

--- a/wheels/install_deps_osx.sh
+++ b/wheels/install_deps_osx.sh
@@ -253,6 +253,9 @@ tar xzf ${glog_pkg} \
     -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
     -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -DWITH_GFLAGS:BOOL=OFF \
+    -DWITH_GTEST:BOOL=OFF \
+    -DBUILD_SHARED_LIBS:BOOL=OFF \
     .. \
     && make -j ${MAKEJ} install \
     && popd >/dev/null 2>&1 \
@@ -287,7 +290,7 @@ tar xzf ${ceres_pkg} \
     -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
     -DBUILD_EXAMPLES=OFF \
     -DBUILD_BENCHMARKS=OFF \
-    -DBUILD_SHARED_LIBS=ON \
+    -DBUILD_SHARED_LIBS=OFF \
     -DBUILD_TESTING=OFF \
     -DGFLAGS=OFF \
     -DSUITESPARSE=OFF \


### PR DESCRIPTION
The 0.2.1 tag introduced ceres-solver + Eigen + GLOG into the compiled dependencies and into the wheel building scripts.  The resulting wheels, when installed into a conda environment, triggered a segfault inside the conda-forge glog package.  I am not sure the cause of this, since the glog library vendored in the so3g wheels should have its name modified to avoid such conflicts.

This work changes the compilation inside the wheels to build and link static versions of glog and ceres-solver.  I tested a locally-built (with cibuildwheel) wheel and verified that the segfault is now gone and that sotodlib master branch unit tests pass using this so3g wheel.