### PR TITLE
Fix lack of support for non-integer crpix

### DIFF
--- a/src/Projection.cxx
+++ b/src/Projection.cxx
@@ -900,7 +900,7 @@ public:
         return -1;
     }
 
-    int crpix[2];
+    double crpix[2];
     double cdelt[2];
     int naxis[2];
     BufferWrapper<double> mapbuf;


### PR DESCRIPTION
In Projection.cxx, crpix was stored as `int[2]` instead of  double[2]`, thus discarding the fractional part of crpix. The most common cases for crpix is for it to be an integer or half-integer. This bug therefore has the potential to cause the effective pointing to be off by half a pixel. I haven't checked how much this affected our SO mapmaking, but it at least affected the test-case Carlos sent me for map-edge wrapping.

If this does affect most of our maps, then we have to be careful about how it interacts with our pointing model, which could have absorbed some of this into it.