### PR TITLE
Speed up RangesMatrix

### DIFF
--- a/demos/demo_proj2.py
+++ b/demos/demo_proj2.py
@@ -116,16 +116,12 @@ else:
     det_weights[n_det//2] = 0.0  # ... unless we mark it as noisy.
 
 # Then back to map.
-print('setup cuts...', end='\n ... ')
-with Timer():
-    cuts = so3g.proj.RangesMatrix.ones(shape=(24, n_det, n_t))
-
 print('Create timestream...', end='\n ... ')
 with Timer():
-    map1 = pe.to_map(None, ptg, ofs, resp, sig1, det_weights, cuts)
+    map1 = pe.to_map(None, ptg, ofs, resp, sig1, det_weights, None)
 
 # Get the weight map (matrix).
-wmap1 = pe.to_weight_map(None, ptg, ofs, resp, det_weights, cuts)
+wmap1 = pe.to_weight_map(None, ptg, ofs, resp, det_weights, None)
 wmap1[1,0] = wmap1[0,1]  # fill in unpopulated entries...
 wmap1[2,0] = wmap1[0,2]
 wmap1[2,1] = wmap1[1,2]

--- a/demos/demo_proj2.py
+++ b/demos/demo_proj2.py
@@ -116,12 +116,16 @@ else:
     det_weights[n_det//2] = 0.0  # ... unless we mark it as noisy.
 
 # Then back to map.
+print('setup cuts...', end='\n ... ')
+with Timer():
+    cuts = so3g.proj.RangesMatrix.ones(shape=(24, n_det, n_t))
+
 print('Create timestream...', end='\n ... ')
 with Timer():
-    map1 = pe.to_map(None, ptg, ofs, resp, sig1, det_weights, None)
+    map1 = pe.to_map(None, ptg, ofs, resp, sig1, det_weights, cuts)
 
 # Get the weight map (matrix).
-wmap1 = pe.to_weight_map(None, ptg, ofs, resp, det_weights, None)
+wmap1 = pe.to_weight_map(None, ptg, ofs, resp, det_weights, cuts)
 wmap1[1,0] = wmap1[0,1]  # fill in unpopulated entries...
 wmap1[2,0] = wmap1[0,2]
 wmap1[2,1] = wmap1[1,2]

--- a/include/Ranges.h
+++ b/include/Ranges.h
@@ -68,11 +68,9 @@ public:
 // Support for working with RangesMatrix, which is basically just a list of Ranges
 template <typename T>
 vector<Ranges<T>> extract_ranges(const bp::object & ival_list) {
-    vector<Ranges<T>> v(bp::len(ival_list));
-    for (int i=0; i<bp::len(ival_list); i++)
-//    const int N = bp::len(ival_list);
-//    vector<Ranges<T>> v(N);
-//    for (int i=0; i<N ; i++)
+    const int N = bp::len(ival_list);
+    vector<Ranges<T>> v(N);
+    for (int i=0; i<N ; i++)
         v[i] = bp::extract<Ranges<T>>(ival_list[i])();
     return v;
 }

--- a/include/Ranges.h
+++ b/include/Ranges.h
@@ -70,6 +70,9 @@ template <typename T>
 vector<Ranges<T>> extract_ranges(const bp::object & ival_list) {
     vector<Ranges<T>> v(bp::len(ival_list));
     for (int i=0; i<bp::len(ival_list); i++)
+//    const int N = bp::len(ival_list);
+//    vector<Ranges<T>> v(N);
+//    for (int i=0; i<N ; i++)
         v[i] = bp::extract<Ranges<T>>(ival_list[i])();
     return v;
 }

--- a/python/proj/ranges.py
+++ b/python/proj/ranges.py
@@ -35,6 +35,7 @@ class RangesMatrix():
         return 'RangesMatrix(' + ','.join(map(str, self.shape)) + ')'
 
     def __len__(self):
+        #return len(self.ranges)
         return self.shape[0]
 
     def copy(self):
@@ -44,7 +45,7 @@ class RangesMatrix():
     def zeros_like(self):
         return RangesMatrix([x.zeros_like() for x in self.ranges],
                             child_shape=self.shape[1:])
-    
+
     def ones_like(self):
         return RangesMatrix([x.ones_like() for x in self.ranges],
                             child_shape=self.shape[1:])
@@ -53,7 +54,7 @@ class RangesMatrix():
         [x.buffer(buff) for x in self.ranges]
         ## just to make this work like Ranges.buffer()
         return self
-    
+
     def buffered(self, buff):
         out = self.copy()
         [x.buffer(buff) for x in out.ranges]
@@ -93,6 +94,9 @@ class RangesMatrix():
           new_rm = rm[..., :]
 
         """
+        #if isinstance(index, (int, np.int32, np.int64)):
+        #    return self.ranges[index]
+
         if not isinstance(index, tuple):
             index = (index,)
 

--- a/python/proj/ranges.py
+++ b/python/proj/ranges.py
@@ -132,7 +132,7 @@ class RangesMatrix():
                 elif self.shape[0] == x.shape[0]:
                     return self.__class__([r + d for r, d in zip(self.ranges, x)], skip_shape_check=True)
             return self.__class__([r + x for r in self.ranges], skip_shape_check=True)
-        
+
     def __mul__(self, x):
         if isinstance(x, Ranges):
             return self.__class__([d * x for d in self.ranges], skip_shape_check=True)
@@ -251,7 +251,7 @@ class RangesMatrix():
             return r
         return RangesMatrix([RangesMatrix.full(shape[1:], fill_value)
                              for i in range(shape[0])],
-                            child_shape=shape[1:])
+                            child_shape=shape[1:], skip_shape_check=True)
 
     @classmethod
     def zeros(cls, shape):

--- a/python/proj/ranges.py
+++ b/python/proj/ranges.py
@@ -35,8 +35,7 @@ class RangesMatrix():
         return 'RangesMatrix(' + ','.join(map(str, self.shape)) + ')'
 
     def __len__(self):
-        #return len(self.ranges)
-        return self.shape[0]
+        return len(self.ranges)
 
     def copy(self):
         return RangesMatrix([x.copy() for x in self.ranges],
@@ -94,8 +93,9 @@ class RangesMatrix():
           new_rm = rm[..., :]
 
         """
-        #if isinstance(index, (int, np.int32, np.int64)):
-        #    return self.ranges[index]
+        # Short-circuit return if this is a simple integer index.
+        if isinstance(index, (int, np.int32, np.int64)):
+            return self.ranges[index]
 
         if not isinstance(index, tuple):
             index = (index,)

--- a/src/Projection.cxx
+++ b/src/Projection.cxx
@@ -9,8 +9,6 @@ using namespace std;
 #include <assert.h>
 #include <math.h>
 
-#include <chrono>
-
 #ifdef _OPENMP
 # include <omp.h>
 #endif // ifdef _OPENMP
@@ -1963,12 +1961,8 @@ bp::object ProjectionEngine<C,P,S>::to_map(
     // For multi-threading, the principle here is that we loop serially
     // over bunches, and then inside each block all threads loop over
     // all detectors in parallel, but the sample ranges are pixel-disjoint.
-    auto start = std::chrono::high_resolution_clock::now();
     auto bunches = derive_ranges(thread_intervals, n_det, n_time,
                                "thread_intervals");
-    auto end2 = std::chrono::high_resolution_clock::now();
-    std::chrono::duration<double, std::milli> elapsed2 = end2 - start;
-    std::cout << "Block2: " << elapsed2.count() << " ms\n";
 
     // First loop over serial bunches
     for(int i_bunch = 0; i_bunch < bunches.size(); i_bunch++) {
@@ -2353,23 +2347,23 @@ int _index_count(const T &) { return T::index_count; }
 
 PYBINDINGS("so3g")
 {
-//    EXPORT_PIX(Flat);
-//    EXPORT_PIX(Quat);
+    EXPORT_PIX(Flat);
+    EXPORT_PIX(Quat);
     EXPORT_PIX(CAR);
-//    EXPORT_PIX(CEA);
-//    EXPORT_PIX(ARC);
-//    EXPORT_PIX(SIN);
-//    EXPORT_PIX(TAN);
-//    EXPORT_PIX(ZEA);
-//
-//    EXPORT_PRECOMP(ProjEng_Precomp_NonTiled);
-//    EXPORT_PRECOMP(ProjEng_Precomp_Tiled);
-//
-//    EXPORT_ENGINE(ProjEng_HP_T_NonTiled);
-//    EXPORT_ENGINE(ProjEng_HP_QU_NonTiled);
-//    EXPORT_ENGINE(ProjEng_HP_TQU_NonTiled);
-//    EXPORT_ENGINE(ProjEng_HP_T_Tiled);
-//    EXPORT_ENGINE(ProjEng_HP_QU_Tiled);
-//    EXPORT_ENGINE(ProjEng_HP_TQU_Tiled);
+    EXPORT_PIX(CEA);
+    EXPORT_PIX(ARC);
+    EXPORT_PIX(SIN);
+    EXPORT_PIX(TAN);
+    EXPORT_PIX(ZEA);
+
+    EXPORT_PRECOMP(ProjEng_Precomp_NonTiled);
+    EXPORT_PRECOMP(ProjEng_Precomp_Tiled);
+
+    EXPORT_ENGINE(ProjEng_HP_T_NonTiled);
+    EXPORT_ENGINE(ProjEng_HP_QU_NonTiled);
+    EXPORT_ENGINE(ProjEng_HP_TQU_NonTiled);
+    EXPORT_ENGINE(ProjEng_HP_T_Tiled);
+    EXPORT_ENGINE(ProjEng_HP_QU_Tiled);
+    EXPORT_ENGINE(ProjEng_HP_TQU_Tiled);
 
 }

--- a/src/Projection.cxx
+++ b/src/Projection.cxx
@@ -9,6 +9,8 @@ using namespace std;
 #include <assert.h>
 #include <math.h>
 
+#include <chrono>
+
 #ifdef _OPENMP
 # include <omp.h>
 #endif // ifdef _OPENMP
@@ -1865,6 +1867,7 @@ vector<vector<vector<RangesInt32>>> derive_ranges(
     bp::object thread_intervals, int n_det, int n_time,
     std::string arg_name)
 {
+    auto start = std::chrono::high_resolution_clock::now();
     // The first index of the returned object should correspond to
     // (OMP) execution thread; the second index is over detectors.
     // The input object can be any of the following:
@@ -1880,31 +1883,45 @@ vector<vector<vector<RangesInt32>>> derive_ranges(
     vector<vector<vector<RangesInt32>>> ivals;
 
     if (isNone(thread_intervals)) {
+        cout << "A\n "; // << RangesInt32::cc_count << "\n";
         // It's None. Generate a single bunch with a single-thread covering all samples
         auto r = RangesInt32(n_time).add_interval(0, n_time);
+        
         vector<vector<RangesInt32>> v(1, vector<RangesInt32>(n_det, r));
+//        cout << "A - " << RangesInt32::cc_count << "\n";
         ivals.push_back(v);
+
     } else if(bp::extract<RangesInt32>(thread_intervals[0]).check()) {
+        cout << "B\n";
         // It's a RangesMatrix (ndet,nranges). Promote to single thread, single bunch
         ivals.push_back(vector<vector<RangesInt32>>(1, extract_ranges<int32_t>(thread_intervals)));
     } else if(bp::extract<RangesInt32>(thread_intervals[0][0]).check()) {
+        cout << "C\n";
         // It's a per-thread RangesMatrix (nthread,ndet,nranges). Promote to single bunch
+        //const int N = bp::len(thread_intervals);
         vector<vector<RangesInt32>> bunch;
         for (int i=0; i<bp::len(thread_intervals); i++)
+            //bunch[i] = extract_ranges<int32_t>(thread_intervals[i]);
             bunch.push_back(extract_ranges<int32_t>(thread_intervals[i]));
         ivals.push_back(bunch);
     } else if(bp::extract<RangesInt32>(thread_intervals[0][0][0]).check()) {
+        cout << "D\n";
         // It's a full multi-bunch (nbunch,nthread,ndet,nranges) thing.
-        for (int i=0; i<bp::len(thread_intervals); i++) {
-            vector<vector<RangesInt32>> bunch;
-            for (int j=0; j<bp::len(thread_intervals[i]); j++)
-                bunch.push_back(extract_ranges<int32_t>(thread_intervals[i][j]));
+        const int N = bp::len(thread_intervals);
+        for (int i=0; i<N; i++) {
+            const int M = bp::len(thread_intervals[i]);
+            vector<vector<RangesInt32>> bunch(M);
+            for (int j=0; j<M; j++)
+                bunch[j] = extract_ranges<int32_t>(thread_intervals[i][j]);
             ivals.push_back(bunch);
         }
     } else {
         // This should not happen
         assert(false);
     }
+    auto end1 = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double, std::milli> elapsed1 = end1 - start;
+
     // Check that these all have the right shape. Maybe consider a standard
     // for loop instead of foreach to give more useful error messages using
     // the index
@@ -1925,6 +1942,12 @@ vector<vector<vector<RangesInt32>>> derive_ranges(
             }
         }
     }
+
+    auto end2 = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double, std::milli> elapsed2 = end2 - end1;
+    std::cout << "Block1: " << elapsed1.count() << " ms\n";
+    std::cout << "Block2: " << elapsed2.count() << " ms\n";
+
     return ivals;
 }
 
@@ -2343,23 +2366,23 @@ int _index_count(const T &) { return T::index_count; }
 
 PYBINDINGS("so3g")
 {
-    EXPORT_PIX(Flat);
-    EXPORT_PIX(Quat);
+//    EXPORT_PIX(Flat);
+//    EXPORT_PIX(Quat);
     EXPORT_PIX(CAR);
-    EXPORT_PIX(CEA);
-    EXPORT_PIX(ARC);
-    EXPORT_PIX(SIN);
-    EXPORT_PIX(TAN);
-    EXPORT_PIX(ZEA);
-
-    EXPORT_PRECOMP(ProjEng_Precomp_NonTiled);
-    EXPORT_PRECOMP(ProjEng_Precomp_Tiled);
-
-    EXPORT_ENGINE(ProjEng_HP_T_NonTiled);
-    EXPORT_ENGINE(ProjEng_HP_QU_NonTiled);
-    EXPORT_ENGINE(ProjEng_HP_TQU_NonTiled);
-    EXPORT_ENGINE(ProjEng_HP_T_Tiled);
-    EXPORT_ENGINE(ProjEng_HP_QU_Tiled);
-    EXPORT_ENGINE(ProjEng_HP_TQU_Tiled);
+//    EXPORT_PIX(CEA);
+//    EXPORT_PIX(ARC);
+//    EXPORT_PIX(SIN);
+//    EXPORT_PIX(TAN);
+//    EXPORT_PIX(ZEA);
+//
+//    EXPORT_PRECOMP(ProjEng_Precomp_NonTiled);
+//    EXPORT_PRECOMP(ProjEng_Precomp_Tiled);
+//
+//    EXPORT_ENGINE(ProjEng_HP_T_NonTiled);
+//    EXPORT_ENGINE(ProjEng_HP_QU_NonTiled);
+//    EXPORT_ENGINE(ProjEng_HP_TQU_NonTiled);
+//    EXPORT_ENGINE(ProjEng_HP_T_Tiled);
+//    EXPORT_ENGINE(ProjEng_HP_QU_Tiled);
+//    EXPORT_ENGINE(ProjEng_HP_TQU_Tiled);
 
 }

--- a/src/Projection.cxx
+++ b/src/Projection.cxx
@@ -1867,7 +1867,6 @@ vector<vector<vector<RangesInt32>>> derive_ranges(
     bp::object thread_intervals, int n_det, int n_time,
     std::string arg_name)
 {
-    auto start = std::chrono::high_resolution_clock::now();
     // The first index of the returned object should correspond to
     // (OMP) execution thread; the second index is over detectors.
     // The input object can be any of the following:
@@ -1883,33 +1882,26 @@ vector<vector<vector<RangesInt32>>> derive_ranges(
     vector<vector<vector<RangesInt32>>> ivals;
 
     if (isNone(thread_intervals)) {
-        cout << "A\n "; // << RangesInt32::cc_count << "\n";
         // It's None. Generate a single bunch with a single-thread covering all samples
         auto r = RangesInt32(n_time).add_interval(0, n_time);
-        
         vector<vector<RangesInt32>> v(1, vector<RangesInt32>(n_det, r));
-//        cout << "A - " << RangesInt32::cc_count << "\n";
         ivals.push_back(v);
-
     } else if(bp::extract<RangesInt32>(thread_intervals[0]).check()) {
-        cout << "B\n";
         // It's a RangesMatrix (ndet,nranges). Promote to single thread, single bunch
         ivals.push_back(vector<vector<RangesInt32>>(1, extract_ranges<int32_t>(thread_intervals)));
     } else if(bp::extract<RangesInt32>(thread_intervals[0][0]).check()) {
-        cout << "C\n";
         // It's a per-thread RangesMatrix (nthread,ndet,nranges). Promote to single bunch
-        const int N = bp::len(thread_intervals);
+        int N = bp::len(thread_intervals);
         vector<vector<RangesInt32>> bunch(N);
         for (int i=0; i<N; i++)
             bunch[i] = extract_ranges<int32_t>(thread_intervals[i]);
         ivals.push_back(bunch);
     } else if(bp::extract<RangesInt32>(thread_intervals[0][0][0]).check()) {
-        cout << "D\n";
         // It's a full multi-bunch (nbunch,nthread,ndet,nranges) thing.
         const int N = bp::len(thread_intervals);
         for (int i=0; i<N; i++) {
-            const int M = bp::len(thread_intervals[i]);
             auto ti_i = thread_intervals[i];
+            int M = bp::len(ti_i);
             vector<vector<RangesInt32>> bunch(M);
             for (int j=0; j<M; j++)
                 bunch[j] = extract_ranges<int32_t>(ti_i[j]);
@@ -1919,9 +1911,6 @@ vector<vector<vector<RangesInt32>>> derive_ranges(
         // This should not happen
         assert(false);
     }
-    auto end1 = std::chrono::high_resolution_clock::now();
-    std::chrono::duration<double, std::milli> elapsed1 = end1 - start;
-
     // Check that these all have the right shape. Maybe consider a standard
     // for loop instead of foreach to give more useful error messages using
     // the index
@@ -1942,12 +1931,6 @@ vector<vector<vector<RangesInt32>>> derive_ranges(
             }
         }
     }
-
-    auto end2 = std::chrono::high_resolution_clock::now();
-    std::chrono::duration<double, std::milli> elapsed2 = end2 - end1;
-    std::cout << "Block1: " << elapsed1.count() << " ms\n";
-    std::cout << "Block2: " << elapsed2.count() << " ms\n";
-
     return ivals;
 }
 
@@ -1980,8 +1963,12 @@ bp::object ProjectionEngine<C,P,S>::to_map(
     // For multi-threading, the principle here is that we loop serially
     // over bunches, and then inside each block all threads loop over
     // all detectors in parallel, but the sample ranges are pixel-disjoint.
+    auto start = std::chrono::high_resolution_clock::now();
     auto bunches = derive_ranges(thread_intervals, n_det, n_time,
                                "thread_intervals");
+    auto end2 = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double, std::milli> elapsed2 = end2 - start;
+    std::cout << "Block2: " << elapsed2.count() << " ms\n";
 
     // First loop over serial bunches
     for(int i_bunch = 0; i_bunch < bunches.size(); i_bunch++) {

--- a/src/Projection.cxx
+++ b/src/Projection.cxx
@@ -1898,11 +1898,10 @@ vector<vector<vector<RangesInt32>>> derive_ranges(
     } else if(bp::extract<RangesInt32>(thread_intervals[0][0]).check()) {
         cout << "C\n";
         // It's a per-thread RangesMatrix (nthread,ndet,nranges). Promote to single bunch
-        //const int N = bp::len(thread_intervals);
-        vector<vector<RangesInt32>> bunch;
-        for (int i=0; i<bp::len(thread_intervals); i++)
-            //bunch[i] = extract_ranges<int32_t>(thread_intervals[i]);
-            bunch.push_back(extract_ranges<int32_t>(thread_intervals[i]));
+        const int N = bp::len(thread_intervals);
+        vector<vector<RangesInt32>> bunch(N);
+        for (int i=0; i<N; i++)
+            bunch[i] = extract_ranges<int32_t>(thread_intervals[i]);
         ivals.push_back(bunch);
     } else if(bp::extract<RangesInt32>(thread_intervals[0][0][0]).check()) {
         cout << "D\n";
@@ -1910,9 +1909,10 @@ vector<vector<vector<RangesInt32>>> derive_ranges(
         const int N = bp::len(thread_intervals);
         for (int i=0; i<N; i++) {
             const int M = bp::len(thread_intervals[i]);
+            auto ti_i = thread_intervals[i];
             vector<vector<RangesInt32>> bunch(M);
             for (int j=0; j<M; j++)
-                bunch[j] = extract_ranges<int32_t>(thread_intervals[i][j]);
+                bunch[j] = extract_ranges<int32_t>(ti_i[j]);
             ivals.push_back(bunch);
         }
     } else {


### PR DESCRIPTION
Addresses a few slow things ...
- len was implemented as .shape[0], which is not good.
- getitem[int] now avoids all the slicing logic.
- .ones / .zeros / .full now skips shape checking.
- C++ code dealing with vector<Ranges> caches len and preallocates vectors.

With very rough profiling, these changes speed up processing of complex RangesMatrix objects, in C++ code, by a factor of 30 or so.

Thanks to @skhrg for identifying the inefficiencies here!